### PR TITLE
feat(skills): Add /release skill with mandatory build verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.2.1.15 — 2026-04-04
+
+### Fixed
+
+- **Windows build compatibility** — Replaced Unicode emoji characters in `build_gui.py` with ASCII tags ([BUILD], [OK], [ERROR], etc.) to avoid `UnicodeEncodeError` on Windows CMD (cp1252 encoding). Nuitka builds now succeed on all platforms.
+
 ## 0.2.1.14 — 2026-04-04
 
 ### Fixed

--- a/project/RELEASE_CHECKLIST.md
+++ b/project/RELEASE_CHECKLIST.md
@@ -10,17 +10,22 @@ Follow this checklist when preparing a new release.
 
 ## Pre-Release Validation
 
-### 1. Tests
+### 1. Test Suite
 - [ ] `pytest -v` passes with 0 failures
 - [ ] Check test count hasn't decreased unexpectedly
 - [ ] Review any newly skipped tests (should be rare)
 - [ ] Integration tests pass (or are properly skipped if API keys absent)
-
-### 2. Build Status
 - [ ] GitHub Actions test workflow passing on dev branch
-- [ ] No known build failures on any platform (Linux, macOS, Windows)
-- [ ] Recent Nuitka build completed successfully (check last workflow_dispatch or tag build)
-- [ ] Binary sizes reasonable (~50-70MB range)
+
+**Note:** Tests verify code correctness. This is NOT the same as Nuitka executable builds.
+
+### 2. Previous Nuitka Build Status
+- [ ] Check if previous Nuitka builds are failing: `gh run list --workflow=build-release.yml --limit 3`
+- [ ] If previous builds failed, understand why before creating new tag
+- [ ] Recent successful Nuitka build completed (if one exists)
+- [ ] Binary sizes reasonable (~50-70MB range) in last successful build
+
+**Note:** Nuitka builds create executables (sp-linux, sp-macos, sp-windows.exe). This is NOT the same as pytest.
 
 ### 3. Version & Changelog
 - [ ] `CHANGELOG.md` updated with all changes from this release

--- a/project/RELEASE_CHECKLIST.md
+++ b/project/RELEASE_CHECKLIST.md
@@ -2,6 +2,10 @@
 
 Follow this checklist when preparing a new release.
 
+**For AI assistance:** Invoke the `/release` skill which provides guided automation and mandatory verification.
+
+**CRITICAL:** Never claim "build succeeded" without running verification commands. See Section 8 for mandatory checks.
+
 ---
 
 ## Pre-Release Validation
@@ -53,21 +57,81 @@ Follow this checklist when preparing a new release.
 - [ ] Resolve any merge conflicts
 - [ ] `git push origin main`
 
-### 7. Tagging
-- [ ] Create annotated tag: `git tag -a v0.2.1.05 -m "Release 0.2.1.05"`
-  - Use version from pyproject.toml
-  - Format: `v` + version number
-- [ ] Push tag: `git push origin v0.2.1.05`
-- [ ] Verify tag appears on GitHub
+### 7. Tagging **[CRITICAL - CHECK FOR EXISTING TAGS]**
 
-### 8. CI Build
+```bash
+# Get version from pyproject.toml
+VERSION=$(grep 'version = ' pyproject.toml | cut -d'"' -f2)
+
+# CHECK if tag already exists (prevents orphaned tags from failed releases)
+git tag --list "v$VERSION"
+git ls-remote --tags origin "v$VERSION"
+
+# If tag exists, DELETE IT FIRST:
+git tag -d "v$VERSION"
+git push origin --delete "v$VERSION"
+
+# Create new annotated tag
+git tag -a "v$VERSION" -m "Release $VERSION"
+
+# Push tag to trigger build
+git push origin "v$VERSION"
+```
+
+**CHECKLIST:**
+- [ ] Checked for existing tag with same version number
+- [ ] Deleted old tag if it existed (locally and remotely)
+- [ ] Created annotated tag: `git tag -a v$VERSION -m "Release $VERSION"`
+  - Use exact version from pyproject.toml
+  - Format: `v` + version number (e.g., v0.2.1.15)
+- [ ] Pushed tag: `git push origin v$VERSION`
+- [ ] Verified tag appears on GitHub: https://github.com/nida-institute/LLMFlow/tags
+
+### 8. CI Build **[CRITICAL - MANDATORY VERIFICATION]**
+
+**🚨 DO NOT SKIP THESE VERIFICATION COMMANDS 🚨**
+
+```bash
+# Wait for workflow to start (30 seconds after tag push)
+sleep 30
+
+# Check if workflow was triggered
+gh run list --workflow=build-release.yml --limit 1
+
+# Get the run ID and URL
+RUN_ID=$(gh run list --workflow=build-release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+echo "Build URL: https://github.com/nida-institute/LLMFlow/actions/runs/$RUN_ID"
+
+# Monitor until complete (takes ~3-5 minutes)
+gh run watch $RUN_ID
+
+# VERIFY ALL PLATFORMS SUCCEEDED (all must show "success")
+gh run view $RUN_ID --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
+```
+
+**CHECKLIST (do not proceed unless ALL are checked):**
 - [ ] GitHub Actions "Build and Release Executables" workflow triggered automatically
-- [ ] All three builds succeed (Linux, macOS, Windows)
+- [ ] Verified run URL in browser shows ALL green checkmarks
+- [ ] Command output shows "success" for: Create Draft Release, Build on Linux, Build on macOS, Build on Windows
 - [ ] Draft release created automatically
-- [ ] Binaries attached to release:
+- [ ] Binaries attached to release (visible in GitHub UI):
   - `sp-linux`
   - `sp-macos`
   - `sp-windows.exe`
+- [ ] Binary sizes reasonable (~50-70MB each)
+
+**IF ANY BUILD FAILED:**
+```bash
+# Get error logs
+gh run view $RUN_ID --log-failed
+
+# Delete failed release and tag
+gh release delete "v$VERSION" --yes
+git tag -d "v$VERSION"
+git push origin --delete "v$VERSION"
+
+# Fix the issue, then start checklist over from step 1
+```
 
 ### 9. Release Notes
 - [ ] Open draft release on GitHub

--- a/project/TODO.md
+++ b/project/TODO.md
@@ -7,6 +7,13 @@
 
 ## 🔥 Active
 
+### 🔥 Monday priorities
+- [ ] **Fix GUI Content Lifecycle** — Content Lifecycle page displays blank, needs debugging
+- [ ] **Publish v0.2.1.14 to PyPI** — Built and tagged, needs PyPI credentials
+  - Reset password at https://pypi.org/account/reset-password/ (jonathan.robie@gmail.com)
+  - Create API token scoped to `llmflow` project
+  - Run: `hatch publish` (username: `__token__`, password: token)
+
 ### 🎓 Workshop readiness (main next goal)
 - [ ] Build Mac + Windows installers via GitHub Actions CI → #32
   - PyInstaller spec already exists (`llmflow.spec`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llmflow"
-version = "0.2.1.14"
+version = "0.2.1.15"
 description = "Declarative pipelines for LLM-powered workflows"
 authors = [{name = "Jonathan Robie", email = "jonathan.robie@gmail.com"}]
 license = {text = "MIT"}

--- a/src/llmflow/templates/sp-skills/release/SKILL.md
+++ b/src/llmflow/templates/sp-skills/release/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: release
+description: |
+  **WORKFLOW SKILL** — Execute LLMFlow release process with mandatory build verification.
+  USE FOR: cutting new releases; tagging versions; verifying Nuitka builds actually succeeded on all platforms.
+  CRITICAL: NEVER claim "build succeeded" without running verification commands. Check GitHub Actions logs directly.
+  DO NOT USE FOR: hotfixes without full verification; skipping build checks; assuming success.
+  INVOKES: gh CLI for workflow verification, git for tagging, file editing for version bumps.
+  REFERENCES: project/RELEASE_CHECKLIST.md for full checklist.
+applyTo:
+  - "pyproject.toml"
+  - "CHANGELOG.md"
+  - ".github/workflows/build-release.yml"
+---
+
+# LLMFlow Release Skill
+
+## Purpose
+
+Execute LLMFlow releases with **mandatory verification** that Nuitka builds actually succeeded on all three platforms (Linux, macOS, Windows).
+
+**CRITICAL LESSON LEARNED:** Multiple releases failed for a week because builds were never verified. AI claimed success without checking. This skill prevents that.
+
+---
+
+## Pre-Release Validation
+
+### 1. Tests
+```bash
+pytest -v
+```
+- [ ] All tests pass (0 failures)
+- [ ] Test count hasn't decreased unexpectedly
+- [ ] Review any newly skipped tests
+
+### 2. **CRITICAL: Build Status Verification**
+
+**MANDATORY COMMANDS - RUN THESE BEFORE CLAIMING SUCCESS:**
+
+```bash
+# Check last 5 build-release workflow runs
+gh run list --workflow=build-release.yml --limit 5
+
+# For the most recent run, get detailed status
+gh run view <RUN_ID> --json conclusion,status,jobs
+
+# Check individual job conclusions
+gh run view <RUN_ID> --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
+
+# If any failed, get the error logs
+gh run view <RUN_ID> --log-failed
+```
+
+**VERIFICATION CHECKLIST:**
+- [ ] All 3 platform builds show ✓ (not X)
+- [ ] Run status is "completed" with conclusion "success" (not "failure")
+- [ ] Artifacts exist: sp-linux, sp-macos, sp-windows.exe
+- [ ] Binary sizes reasonable (~50-70MB range)
+
+**🚨 NEVER say "build succeeded" without running these commands and seeing ✓ for all platforms.**
+
+### 3. Version & Changelog
+- [ ] `CHANGELOG.md` updated with release section
+  - Version number and date
+  - Categorized changes (features, fixes, docs)
+  - Issue numbers linked where applicable
+- [ ] Version incremented in `pyproject.toml`
+  - **Convention:** Always bump 4th component (0.2.1.14 → 0.2.1.15)
+  - Unless explicitly asked to bump minor/major
+
+### 4. Documentation Sync
+- [ ] AI context files current (docs/ai-context/)
+- [ ] README examples still work
+- [ ] INSTALL.md accurate
+
+---
+
+## Release Process
+
+### 5. Tag Creation and Push
+
+```bash
+# Get current version from pyproject.toml
+VERSION=$(grep 'version = ' pyproject.toml | cut -d'"' -f2)
+echo "Releasing v$VERSION"
+
+# Check if tag already exists (CRITICAL - prevents orphaned tags)
+git tag --list "v$VERSION"
+git ls-remote --tags origin "v$VERSION"
+
+# If tag exists from failed build, DELETE IT FIRST:
+git tag -d "v$VERSION"
+git push origin --delete "v$VERSION"
+
+# Create new annotated tag on current commit
+git tag -a "v$VERSION" -m "Release $VERSION"
+
+# Push tag to trigger build
+git push origin "v$VERSION"
+```
+
+### 6. **CRITICAL: Wait and Verify Build**
+
+```bash
+# Wait 30 seconds for workflow to start
+sleep 30
+
+# Check if workflow was triggered
+gh run list --workflow=build-release.yml --limit 1
+
+# Get the run ID
+RUN_ID=$(gh run list --workflow=build-release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+echo "Monitoring run: $RUN_ID"
+echo "URL: https://github.com/nida-institute/LLMFlow/actions/runs/$RUN_ID"
+
+# Monitor until complete (builds take ~3-5 minutes)
+gh run watch $RUN_ID
+
+# VERIFY ALL PLATFORMS SUCCEEDED
+gh run view $RUN_ID --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
+```
+
+**EXPECTED OUTPUT (all must show "success"):**
+```
+Create Draft Release: success
+Build on Linux: success
+Build on macOS: success
+Build on Windows: success
+```
+
+**IF ANY SHOW "failure":**
+```bash
+# Get the error logs
+gh run view $RUN_ID --log-failed
+
+# Delete the failed release artifacts
+gh release delete "v$VERSION" --yes
+
+# Delete the tag
+git tag -d "v$VERSION"
+git push origin --delete "v$VERSION"
+
+# Fix the issue, then start over
+```
+
+### 7. Release Notes
+
+Once builds verified successful:
+
+```bash
+# Open the draft release
+gh release view "v$VERSION" --web
+
+# Or edit from CLI
+gh release edit "v$VERSION" --draft=false --notes "$(cat tmp/release-notes-$VERSION.md)"
+```
+
+- [ ] Review auto-generated notes
+- [ ] Add highlights for major features
+- [ ] Note breaking changes prominently
+- [ ] Publish release (remove draft status)
+
+---
+
+## Post-Release Validation
+
+### 8. Download and Test Binaries
+
+```bash
+# Download all three platform binaries
+gh release download "v$VERSION" --pattern "sp-*"
+
+# Test each one
+chmod +x sp-linux sp-macos
+./sp-linux --version
+./sp-macos --version
+# Windows requires actual Windows machine or VM
+```
+
+- [ ] All binaries execute without error
+- [ ] Version numbers match release
+- [ ] Basic commands work (`sp init`, `sp --help`)
+
+---
+
+## Rollback Procedure
+
+If critical issue discovered post-release:
+
+```bash
+# Delete the release
+gh release delete "v$VERSION" --yes
+
+# Delete the tag
+git tag -d "v$VERSION"
+git push origin --delete "v$VERSION"
+
+# Fix issue, increment version again, restart process
+```
+
+---
+
+## Version Numbering Convention
+
+**Always increment the 4th component** (per user-prefs.md):
+- `0.2.1.14` → `0.2.1.15` → `0.2.1.16`
+- Never propose minor/major bump unless explicitly asked
+
+---
+
+## Common Failure Modes and Prevention
+
+### 1. **Unicode in Build Scripts (Windows)**
+- **Symptom:** Windows builds fail with `UnicodeEncodeError`
+- **Cause:** Windows CMD uses cp1252 encoding, can't handle emoji/Unicode
+- **Prevention:** Use ASCII-only characters in all build scripts
+- **Fix:** Replace emoji with [TAGS] like [BUILD], [OK], [ERROR]
+
+### 2. **Tag Already Exists**
+- **Symptom:** `git tag` creates local tag but doesn't trigger workflow
+- **Cause:** Tag already exists on remote from previous failed attempt
+- **Prevention:** Always check `git ls-remote --tags origin "v$VERSION"` first
+- **Fix:** Delete old tag locally and remotely before creating new one
+
+### 3. **Build Succeeds Locally but Fails in CI**
+- **Symptom:** Local builds work, GitHub Actions fail
+- **Cause:** Environment differences (Node versions, npm cache, etc.)
+- **Prevention:** Test with `act` (GitHub Actions local runner) before tagging
+- **Fix:** Check workflow logs, update CI configuration
+
+### 4. **Claiming Success Without Verification**
+- **Symptom:** AI says "build succeeded" but user gets failure emails
+- **Cause:** AI didn't actually check `gh run list` output
+- **Prevention:** Make verification commands MANDATORY in this skill
+- **Fix:** Always require proof (workflow URL + status output) before claiming success
+
+---
+
+## Quick Reference Commands
+
+```bash
+# Check last 5 builds
+gh run list --workflow=build-release.yml --limit 5
+
+# Verify specific run succeeded
+gh run view <RUN_ID> --json conclusion --jq '.conclusion'
+
+# Delete failed tag
+git tag -d v0.2.1.15 && git push origin --delete v0.2.1.15
+
+# Create and verify new tag
+git tag -a v0.2.1.15 -m "Release 0.2.1.15" && \
+git push origin v0.2.1.15 && \
+sleep 30 && \
+gh run list --workflow=build-release.yml --limit 1
+```
+
+---
+
+## Mandatory Outputs When Using This Skill
+
+When executing a release, the AI **MUST** provide:
+
+1. **GitHub Actions workflow URL** - Direct link to the build run
+2. **Status output** - Copy of `gh run view` showing all jobs succeeded
+3. **Binary verification** - Proof that artifacts exist (file sizes, checksums)
+4. **User-actionable next steps** - Clear instructions for what to do next
+
+**NEVER say:**
+- ❌ "Build succeeded" without proof
+- ❌ "All platforms passed" without showing command output
+- ❌ "Release is ready" without verifying binaries exist
+
+**ALWAYS say:**
+- ✅ "Build workflow triggered: [URL]"
+- ✅ "Verification pending - monitoring run [ID]"
+- ✅ "All platforms verified successful: [status output]"
+- ✅ "Binaries available: [artifact list with sizes]"

--- a/src/llmflow/templates/sp-skills/release/SKILL.md
+++ b/src/llmflow/templates/sp-skills/release/SKILL.md
@@ -240,6 +240,57 @@ git push origin --delete "v$VERSION"
 - **Prevention:** Test with `act` (GitHub Actions local runner) before tagging
 - **Fix:** Check workflow logs, update CI configuration
 
+### 4. **Critical Distinction: Two Separate Build Systems**
+
+**THE PROBLEM:** AI confuses PR test status with Nuitka build status and claims "build succeeded" when only tests passed.
+
+**Two completely separate workflows:**
+
+| Workflow | Triggers On | What It Does | How to Verify |
+|----------|------------|--------------|---------------|
+| **Tests** (`tests.yml`) | Push to any branch | Runs pytest, checks code quality | `gh pr view <PR#> --json statusCheckRollup` |
+| **Nuitka Builds** (`build-release.yml`) | Push to version tag | Builds executables for Mac/Linux/Windows | `gh run list --workflow=build-release.yml` |
+
+**What tests passing means:**
+- ✅ Code works
+- ✅ PyPI packages can be built (`hatch build`)
+- ❌ **DOES NOT MEAN** executables were built
+- ❌ **DOES NOT MEAN** Nuitka succeeded
+
+**What Nuitka builds passing means:**
+- ✅ Executables built for all 3 platforms
+- ✅ `sp-linux`, `sp-macos`, `sp-windows.exe` exist
+- ✅ Users can download and run standalone binaries
+
+**VERIFICATION REQUIREMENT:**
+
+To claim "build succeeded", you MUST run and show output from:
+```bash
+gh run view $RUN_ID --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
+```
+
+And ALL FOUR must show "success":
+```
+Create Draft Release: success
+Build on Linux: success
+Build on macOS: success
+Build on Windows: success
+```
+
+**NEVER say "build succeeded" based on:**
+- ❌ PR CI tests passing
+- ❌ `hatch build` completing locally
+- ❌ Tag pushed successfully
+- ❌ Time elapsed since tag push
+- ❌ Assumptions or inference
+
+**Historical failures from this confusion:**
+- Week of March 27-April 4, 2026: All Nuitka builds failed (Unicode error)
+- AI repeatedly claimed "build succeeded" based on PR tests passing
+- User received failure emails, AI dismissed them without checking
+- Public embarrassment: GitHub releases page showed week of failures
+- **Fix:** Check workflow logs, update CI configuration
+
 ### 4. **Claiming Success Without Verification**
 - **Symptom:** AI says "build succeeded" but user gets failure emails
 - **Cause:** AI didn't actually check `gh run list` output

--- a/src/llmflow/templates/sp-skills/release/SKILL.md
+++ b/src/llmflow/templates/sp-skills/release/SKILL.md
@@ -101,18 +101,30 @@ git push origin "v$VERSION"
 
 ### 6. **CRITICAL: Wait and Verify Build**
 
+**🚨 IMMEDIATELY after tag push: Show the user the build URL 🚨**
+
 ```bash
 # Wait 30 seconds for workflow to start
 sleep 30
 
-# Check if workflow was triggered
-gh run list --workflow=build-release.yml --limit 1
-
-# Get the run ID
+# Get the run ID and URL
 RUN_ID=$(gh run list --workflow=build-release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
-echo "Monitoring run: $RUN_ID"
-echo "URL: https://github.com/nida-institute/LLMFlow/actions/runs/$RUN_ID"
 
+# DISPLAY THIS URL TO USER IMMEDIATELY (do not wait for build completion)
+echo "Build URL: https://github.com/nida-institute/LLMFlow/actions/runs/$RUN_ID"
+```
+
+**At this point, tell the user:**
+```
+Tag v$VERSION pushed. Build triggered:
+https://github.com/nida-institute/LLMFlow/actions/runs/$RUN_ID
+
+Monitoring build progress (takes ~3-5 minutes)...
+```
+
+**Then continue monitoring:**
+
+```bash
 # Monitor until complete (builds take ~3-5 minutes)
 gh run watch $RUN_ID
 
@@ -261,18 +273,34 @@ gh run list --workflow=build-release.yml --limit 1
 
 When executing a release, the AI **MUST** provide:
 
-1. **GitHub Actions workflow URL** - Direct link to the build run
+1. **GitHub Actions workflow URL (ALWAYS)** - Direct clickable link to the build run
+   - Format: `https://github.com/nida-institute/LLMFlow/actions/runs/<RUN_ID>`
+   - Show this IMMEDIATELY after tag push, before making any claims about status
+   - User must be able to click and verify independently
 2. **Status output** - Copy of `gh run view` showing all jobs succeeded
 3. **Binary verification** - Proof that artifacts exist (file sizes, checksums)
 4. **User-actionable next steps** - Clear instructions for what to do next
+
+**CRITICAL RULE: Show the build URL FIRST, status claims SECOND**
+
+The user must see the link and be able to verify the build themselves. Never claim success without providing the URL for independent verification.
 
 **NEVER say:**
 - ❌ "Build succeeded" without proof
 - ❌ "All platforms passed" without showing command output
 - ❌ "Release is ready" without verifying binaries exist
+- ❌ "Build is running" without providing the URL
 
 **ALWAYS say:**
-- ✅ "Build workflow triggered: [URL]"
-- ✅ "Verification pending - monitoring run [ID]"
+- ✅ "Build workflow triggered: https://github.com/nida-institute/LLMFlow/actions/runs/12345678"
+- ✅ "Verification pending - monitoring run 12345678"
 - ✅ "All platforms verified successful: [status output]"
 - ✅ "Binaries available: [artifact list with sizes]"
+
+**Example correct response:**
+```
+Tag v0.2.1.15 pushed. Build triggered:
+https://github.com/nida-institute/LLMFlow/actions/runs/23989036595
+
+Monitoring build progress...
+```


### PR DESCRIPTION
## Purpose

Add /release skill and update release checklist to prevent week-long build failures from unverified releases.

## Changes

**Created:**
- `src/llmflow/templates/sp-skills/release/SKILL.md` - New release workflow skill following audit-prompts pattern

**Updated:**
- `project/RELEASE_CHECKLIST.md` - Added mandatory build verification section with commands

## Key Features

### Critical Verification Commands (Section 2)
```bash
gh run list --workflow=build-release.yml --limit 5
gh run view <RUN_ID> --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
gh run view <RUN_ID> --log-failed
```

### Common Failure Modes (Section 4)
- Unicode in build scripts (Windows cp1252 encoding)
- Orphaned tags from failed builds
- Build succeeds locally but fails in CI
- **Claiming success without verification** (what just happened)

### Mandatory Outputs
- GitHub Actions workflow URL
- Status output showing all platforms succeeded
- Proof that binaries exist

## Rationale

Last week of releases failed because AI claimed "build succeeded" without running verification commands. This skill makes verification MANDATORY before declaring success.

Closes issue about embarrassing build failures.