### PR TITLE
fix(build): Use shell=True for npm commands on Windows

### DIFF
--- a/build_gui.py
+++ b/build_gui.py
@@ -38,10 +38,11 @@ def main():
         npm_cmd = "ci" if os.getenv("CI") else "install"
         print(f"\n[INSTALL] Installing npm dependencies (npm {npm_cmd})...")
         result = subprocess.run(
-            ["npm", npm_cmd],
+            f"npm {npm_cmd}",
             cwd=frontend_dir,
             capture_output=True,
-            text=True
+            text=True,
+            shell=True
         )
         if result.returncode != 0:
             print(f"[ERROR] npm {npm_cmd} failed:")
@@ -52,10 +53,11 @@ def main():
     # Build frontend
     print("\n[BUILD] Building React frontend (production)...")
     result = subprocess.run(
-        ["npm", "run", "build"],
+        "npm run build",
         cwd=frontend_dir,
         capture_output=True,
-        text=True
+        text=True,
+        shell=True
     )
     if result.returncode != 0:
         print(f"[ERROR] npm build failed:")


### PR DESCRIPTION
## Issue

v0.2.1.15 build failed on Windows with:
```
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

When trying to run `npm run build` at line 54 of build_gui.py.

## Root Cause

Windows requires `npm.cmd` not `npm` executable. Using `subprocess.run(["npm", ...])` fails because it doesn't find the .cmd wrapper.

## Fix

Changed both npm subprocess calls to use `shell=True`:
- Line 40: `subprocess.run("npm ci", ..., shell=True)`
- Line 54: `subprocess.run("npm run build", ..., shell=True)`

This allows the shell to resolve npm to npm.cmd on Windows while still working on Unix.

## Verification

Build URL for failed attempt: https://github.com/nida-institute/LLMFlow/actions/runs/24001334842

After merge, will trigger new build to verify all 3 platforms succeed.