### PR TITLE
feat: Add window step type for sliding/tumbling/condition-based windowing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "flask-socketio>=5.3.0",
   "flask-cors>=4.0.0",
   "python-socketio>=5.10.0",
+  "tiktoken>=0.7.0",
 ]
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/llmflow/runner.py
+++ b/src/llmflow/runner.py
@@ -1658,12 +1658,87 @@ def _build_windows_condition(items: list, start_when: str, end_when: str | None,
     return windows
 
 
+def _build_windows_token(
+    items: list,
+    size_by_tokens: int,
+    stride_by_tokens: int,
+    model: str,
+    include_partial: bool,
+) -> list[list]:
+    """Token-aware sliding windows using tiktoken.
+
+    Each window accumulates items until adding the next would exceed size_by_tokens.
+    The next window begins at the start of the overlap suffix: the largest suffix of
+    the current window whose total token count <= stride_by_tokens.  This implements
+    token-level sliding overlap (stride_by_tokens=0 => tumbling / no overlap).
+
+    Items are serialised as JSON (dicts/lists) or str() for token counting, matching
+    what the LLM prompt will receive.
+    """
+    try:
+        import tiktoken  # noqa: PLC0415
+    except ImportError:
+        raise ImportError(
+            "tiktoken is required for token-based windowing. "
+            "Install with: pip install tiktoken"
+        ) from None
+
+    try:
+        enc = tiktoken.encoding_for_model(model)
+    except KeyError:
+        enc = tiktoken.get_encoding("cl100k_base")
+
+    def count_tokens(item: Any) -> int:
+        text = json.dumps(item, ensure_ascii=False) if isinstance(item, (dict, list)) else str(item)
+        return len(enc.encode(text))
+
+    counts = [count_tokens(item) for item in items]
+    n = len(items)
+    windows: list[list] = []
+    start = 0
+
+    while start < n:
+        # Greedily accumulate items until adding the next would overflow.
+        # Always include at least one item even if it alone exceeds size_by_tokens.
+        total = 0
+        end = start
+        while end < n:
+            if total + counts[end] > size_by_tokens and end > start:
+                break
+            total += counts[end]
+            end += 1
+
+        # is_partial: window ended because we ran out of items (not overflow)
+        is_partial = end == n
+        if not is_partial or include_partial:
+            windows.append(items[start:end])
+
+        if stride_by_tokens <= 0:
+            start = end  # tumbling: no overlap
+        else:
+            # Find the largest suffix [k:end] with total tokens <= stride_by_tokens
+            overlap_tokens = 0
+            k = end
+            while k > start:
+                if overlap_tokens + counts[k - 1] <= stride_by_tokens:
+                    overlap_tokens += counts[k - 1]
+                    k -= 1
+                else:
+                    break
+            # Always advance at least 1 item to prevent infinite loop when the
+            # overlap covers the entire window (stride_by_tokens >= window tokens).
+            start = max(k, start + 1)
+
+    return windows
+
+
 def run_window_step(step: Dict[str, Any], context: Dict[str, Any], pipeline_config: Dict[str, Any]) -> str | None:
     """Execute a window step — iterate over windows of the input list."""
-    input_data = resolve(step.get("input", []), context)
+    step_name = step.get("name", "unnamed")
+    input_data = resolve(step.get("input", step.get("over", [])), context)
     if not isinstance(input_data, list):
         raise ValueError(
-            f"Window step '{step.get('name', 'unnamed')}': input must resolve to a list, "
+            f"Window step '{step_name}': input must resolve to a list, "
             f"got {type(input_data).__name__}"
         )
 
@@ -1674,18 +1749,32 @@ def run_window_step(step: Dict[str, Any], context: Dict[str, Any], pipeline_conf
     include_partial = step.get("include_partial", True)
     start_when = step.get("start_when")
     end_when = step.get("end_when")
+    size_by_tokens = step.get("size_by_tokens")
+    stride_by_tokens = step.get("stride_by_tokens", 0)
+    _model_raw = resolve(step.get("model", "gpt-4o"), context)
+    model: str = str(_model_raw) if not isinstance(_model_raw, str) else _model_raw
 
     # Build window list
     if start_when:
         windows = _build_windows_condition(input_data, start_when, end_when, context)
+    elif size_by_tokens is not None:
+        if not isinstance(size_by_tokens, int) or size_by_tokens < 1:
+            raise ValueError(
+                f"Window step '{step_name}': 'size_by_tokens' must be a positive integer"
+            )
+        if not isinstance(stride_by_tokens, int) or stride_by_tokens < 0:
+            raise ValueError(
+                f"Window step '{step_name}': 'stride_by_tokens' must be a non-negative integer"
+            )
+        windows = _build_windows_token(input_data, size_by_tokens, stride_by_tokens, model, include_partial)
     else:
         if not isinstance(size, int):
             raise ValueError(
-                f"Window step '{step.get('name', 'unnamed')}': 'size' must be a positive integer"
+                f"Window step '{step_name}': 'size' must be a positive integer"
             )
         if not isinstance(stride, int):
             raise ValueError(
-                f"Window step '{step.get('name', 'unnamed')}': 'stride' must be a positive integer"
+                f"Window step '{step_name}': 'stride' must be a positive integer"
             )
         windows = _build_windows_fixed(input_data, size, stride, include_partial)
 
@@ -1770,6 +1859,13 @@ def run_window_step(step: Dict[str, Any], context: Dict[str, Any], pipeline_conf
         for output_var in output_vars:
             if output_var in iteration_context:
                 context[output_var] = iteration_context[output_var]
+
+    # Optional merge step: runs once after all windows complete with the full context
+    merge_config = step.get("merge")
+    if merge_config:
+        logger.info(f"🔀 Window step '{step_name}': running merge")
+        merge_result = run_function_step(merge_config, context, pipeline_config)
+        handle_step_outputs(merge_config, merge_result, context)
 
     return None
 

--- a/src/llmflow/runner.py
+++ b/src/llmflow/runner.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -1475,108 +1476,202 @@ def resolve_template(template: str, context: Dict[str, Any]) -> str:
     return resolved
 
 
+def _collect_loop_outputs(steps_list: list) -> tuple[set, set]:
+    """Recursively collect append_to targets and output variable names from a steps list."""
+    append_targets: set = set()
+    output_vars: set = set()
+    for s in steps_list:
+        if "append_to" in s:
+            append_targets.add(s["append_to"])
+        if "outputs" in s:
+            ov = s["outputs"]
+            if isinstance(ov, str):
+                output_vars.add(ov)
+            elif isinstance(ov, list):
+                output_vars.update(ov)
+        if "steps" in s:
+            na, no = _collect_loop_outputs(s["steps"])
+            append_targets.update(na)
+            output_vars.update(no)
+    return append_targets, output_vars
+
+
+def _setup_iteration_context(
+    index: int,
+    item: Any,
+    context: Dict[str, Any],
+    item_var: str,
+    step_name: str,
+    debug_label_template: str | None,
+) -> Dict[str, Any]:
+    """Build the isolated context for one for-each iteration."""
+    iteration_context = deepcopy(context)
+    iteration_context[item_var] = item
+    iteration_context["_for_each_index"] = index
+
+    parent_stack = iteration_context.get("_for_each_stack") or []
+    stack = [dict(frame) for frame in parent_stack] if parent_stack else []
+
+    label_fragment = None
+    if debug_label_template:
+        try:
+            resolved_label = resolve(debug_label_template, iteration_context)
+            if resolved_label is not None:
+                label_fragment = _format_iteration_fragment(resolved_label)
+        except Exception as exc:
+            logger.debug(f"debug_label resolution failed in for-each '{step_name}': {exc}")
+
+    value_fragment = _format_iteration_fragment(item)
+    new_frame = {
+        "level": len(stack) + 1,
+        "variable": item_var,
+        "value": value_fragment,
+        "label": label_fragment or "",
+        "index": index,
+    }
+    stack.append(new_frame)
+    iteration_context["_for_each_stack"] = stack
+    iteration_context["_for_each_meta"] = new_frame
+    return iteration_context
+
+
+def _run_iteration_steps(
+    iteration_context: Dict[str, Any],
+    steps: list,
+    pipeline_config: Dict[str, Any],
+) -> str | None:
+    """Execute the nested steps for one iteration. Returns after_action or None."""
+    for nested_step in steps:
+        after_action = run_step(nested_step, iteration_context, pipeline_config)
+        if after_action in ("exit", "continue"):
+            return after_action
+    return None
+
+
+def _propagate_iteration_results(
+    iteration_context: Dict[str, Any],
+    context: Dict[str, Any],
+    append_targets: set,
+    output_vars: set,
+    baseline_lengths: Dict[str, int],
+) -> None:
+    """Propagate one iteration's results back to the parent context.
+
+    baseline_lengths maps each append_to target to the length of the parent list
+    at the start of this iteration — only items added by this iteration are propagated.
+    """
+    for target in append_targets:
+        if target in iteration_context and isinstance(iteration_context[target], list):
+            baseline = baseline_lengths.get(target, 0)
+            new_items = iteration_context[target][baseline:]
+            if target not in context:
+                context[target] = list(new_items)
+            else:
+                context[target].extend(new_items)
+
+    for var in output_vars:
+        if var in iteration_context:
+            context[var] = iteration_context[var]
+
+
 def run_for_each_step(step: Dict[str, Any], context: Dict[str, Any], pipeline_config: Dict[str, Any]) -> str | None:
-    """Execute a for-each loop step"""
-    input_data = resolve(step.get("input", []), context)
+    """Execute a for-each loop step, sequentially or in parallel."""
+    _input_raw = resolve(step.get("input", []), context)
+    input_data: list = _input_raw if isinstance(_input_raw, list) else list(_input_raw)
     item_var = step.get("item_var", "item")
     steps = step.get("steps", [])
     debug_label_template = step.get("debug_label")
+    step_name = step.get("name", "unnamed")
+    parallel = step.get("parallel", 1)
 
-    # Collect all append_to targets AND regular outputs
-    def collect_outputs(steps_list):
-        append_targets = set()
-        output_vars = set()
-        for step in steps_list:
-            if "append_to" in step:
-                append_targets.add(step["append_to"])
-            if "outputs" in step:
-                outputs = step["outputs"]
-                if isinstance(outputs, str):
-                    output_vars.add(outputs)
-                elif isinstance(outputs, list):
-                    output_vars.update(outputs)
-            if "steps" in step:
-                nested_append, nested_output = collect_outputs(step["steps"])
-                append_targets.update(nested_append)
-                output_vars.update(nested_output)
-        return append_targets, output_vars
+    append_to_targets, output_vars = _collect_loop_outputs(steps)
 
-    append_to_targets, output_vars = collect_outputs(steps)
+    if parallel and isinstance(parallel, int) and parallel > 1:
+        return _run_for_each_parallel(
+            input_data, item_var, steps, debug_label_template, step_name,
+            parallel, append_to_targets, output_vars, context, pipeline_config,
+        )
 
+    # ── Sequential path ────────────────────────────────────────────────────
     for index, item in enumerate(input_data, start=1):
-        iteration_context = deepcopy(context)
-        iteration_context[item_var] = item
+        # Baseline captured per-iteration: parent list grows as iterations complete
+        baseline_lengths = {t: len(context[t]) for t in append_to_targets if t in context}
 
-        parent_stack = iteration_context.get("_for_each_stack") or []
-        stack = [dict(frame) for frame in parent_stack] if parent_stack else []
+        iteration_context = _setup_iteration_context(
+            index, item, context, item_var, step_name, debug_label_template
+        )
+        after_action = _run_iteration_steps(iteration_context, steps, pipeline_config)
 
-        label_fragment = None
-        if debug_label_template:
-            try:
-                resolved_label = resolve(debug_label_template, iteration_context)
-                if resolved_label is not None:
-                    label_fragment = _format_iteration_fragment(resolved_label)
-            except Exception as exc:
-                logger.debug(
-                    f"debug_label resolution failed in for-each '{step.get('name', 'unnamed')}': {exc}"
-                )
+        if after_action == "exit":
+            logger.info("🛑 'after: exit' in for-each iteration - exiting pipeline")
+            _propagate_iteration_results(
+                iteration_context, context, append_to_targets, output_vars, baseline_lengths
+            )
+            return "exit"
 
-        value_fragment = _format_iteration_fragment(item)
-        new_frame = {
-            "level": len(stack) + 1,
-            "variable": item_var,
-            "value": value_fragment,
-            "label": label_fragment or "",
-            "index": index,
+        _propagate_iteration_results(
+            iteration_context, context, append_to_targets, output_vars, baseline_lengths
+        )
+
+        if after_action == "continue":
+            continue
+
+    return None
+
+
+def _run_for_each_parallel(
+    input_data: list,
+    item_var: str,
+    steps: list,
+    debug_label_template: str | None,
+    step_name: str,
+    parallel: int,
+    append_to_targets: set,
+    output_vars: set,
+    context: Dict[str, Any],
+    pipeline_config: Dict[str, Any],
+) -> str | None:
+    """Parallel execution of for-each iterations with ordered result propagation.
+
+    Each iteration runs in a thread with an isolated deepcopy of the parent context.
+    Results are collected indexed by input position, then propagated in input order —
+    producing identical output to sequential execution.
+
+    The baseline_lengths for all iterations is captured once before any thread starts,
+    since all iterations see the same parent context snapshot (no cross-iteration state).
+    """
+    # Baseline is constant for all parallel iterations (all start from same parent snapshot)
+    baseline_lengths = {t: len(context[t]) for t in append_to_targets if t in context}
+
+    def run_one(index: int, item: Any) -> tuple[int, Dict[str, Any], str | None]:
+        iter_ctx = _setup_iteration_context(
+            index, item, context, item_var, step_name, debug_label_template
+        )
+        after_action = _run_iteration_steps(iter_ctx, steps, pipeline_config)
+        return index, iter_ctx, after_action
+
+    results: Dict[int, tuple[Dict[str, Any], str | None]] = {}
+
+    with ThreadPoolExecutor(max_workers=parallel) as executor:
+        futures = {
+            executor.submit(run_one, i, item): i
+            for i, item in enumerate(input_data, start=1)
         }
-        stack.append(new_frame)
-        iteration_context["_for_each_stack"] = stack
-        iteration_context["_for_each_meta"] = new_frame
+        for future in as_completed(futures):
+            index, iter_ctx, after_action = future.result()  # raises on thread exception
+            results[index] = (iter_ctx, after_action)
 
-        for step in steps:
-            after_action = run_step(step, iteration_context, pipeline_config)
+    # Propagate in input order — restores identical ordering to sequential execution
+    for index in sorted(results):
+        iter_ctx, after_action = results[index]
+        _propagate_iteration_results(
+            iter_ctx, context, append_to_targets, output_vars, baseline_lengths
+        )
+        if after_action == "exit":
+            logger.info(f"🛑 'after: exit' in parallel for-each iteration {index} - exiting pipeline")
+            return "exit"
 
-            if after_action == "exit":
-                logger.info("🛑 'after: exit' in for-each iteration - exiting entire pipeline")
-
-                # Propagate BOTH append_to AND regular outputs before exiting
-                for target in append_to_targets:
-                    if target in iteration_context and isinstance(iteration_context[target], list):
-                        if target not in context:
-                            context[target] = iteration_context[target][:]
-                        else:
-                            original_length = len(context[target])
-                            new_items = iteration_context[target][original_length:]
-                            context[target].extend(new_items)
-
-                # FIX: Also propagate regular outputs before exiting
-                for output_var in output_vars:
-                    if output_var in iteration_context:
-                        context[output_var] = iteration_context[output_var]
-                        logger.debug(f"Propagated output '{output_var}' before exit")
-
-                return "exit"  # Propagate exit to parent
-
-            elif after_action == "continue":
-                logger.info("⏭️  'after: continue' in for-each iteration - skipping to next iteration")
-                break  # Break out of steps loop, continue with next item
-
-        # Normal propagation (no exit)
-        for target in append_to_targets:
-            if target in iteration_context and isinstance(iteration_context[target], list):
-                if target not in context:
-                    context[target] = iteration_context[target][:]
-                else:
-                    original_length = len(context[target])
-                    new_items = iteration_context[target][original_length:]
-                    context[target].extend(new_items)
-
-        # Propagate regular outputs — last-iteration wins, matching Python for-loop semantics
-        for output_var in output_vars:
-            if output_var in iteration_context:
-                context[output_var] = iteration_context[output_var]
-
-    return None  # No exit, normal completion
+    return None
 
 
 def _build_windows_fixed(items: list, size: int, stride: int, include_partial: bool) -> list[list]:

--- a/src/llmflow/runner.py
+++ b/src/llmflow/runner.py
@@ -837,6 +837,8 @@ def run_step(
 
             if step_type == "for-each":
                 local_after_action = run_for_each_step(step, context, pipeline_config or {})
+            elif step_type == "window":
+                local_after_action = run_window_step(step, context, pipeline_config or {})
             elif step_type == "llm":
                 result = run_llm_step(step, context, pipeline_config or {})
                 handle_step_outputs(step, result, context)
@@ -1575,6 +1577,201 @@ def run_for_each_step(step: Dict[str, Any], context: Dict[str, Any], pipeline_co
                 context[output_var] = iteration_context[output_var]
 
     return None  # No exit, normal completion
+
+
+def _build_windows_fixed(items: list, size: int, stride: int, include_partial: bool) -> list[list]:
+    """Generate fixed-size windows (tumbling when stride==size, sliding when stride<size)."""
+    windows = []
+    i = 0
+    while i < len(items):
+        window = items[i:i + size]
+        if len(window) == size or include_partial:
+            windows.append(window)
+        i += stride
+    return windows
+
+
+def _eval_window_condition(expr: str, item: Any, context: dict) -> bool:
+    """
+    Evaluate a window start_when/end_when condition with item in scope.
+
+    Strips the ${...} wrapper if present and calls _safe_eval directly,
+    bypassing resolve() which would incorrectly evaluate boolean expressions
+    (e.g. resolve('${item.marker == "s"}') returns "s", not True/False).
+    """
+    stripped = expr.strip()
+    if stripped.startswith("${") and stripped.endswith("}"):
+        stripped = stripped[2:-1]
+    eval_locals = _build_eval_locals({**context, "item": item})
+    try:
+        return bool(_safe_eval(stripped, eval_locals))
+    except Exception as exc:
+        logger.warning(f"window condition eval failed: {stripped} - {exc}")
+        return False
+
+
+def _build_windows_condition(items: list, start_when: str, end_when: str | None, context: dict) -> list[list]:
+    """
+    Generate condition-based tumbling windows.
+
+    A new window opens when start_when is true for an item.
+    If end_when is provided, the window closes (inclusively) when end_when is true.
+    If end_when is absent, the window closes when the next start_when fires.
+    Items before the first start_when and after the last closed window are dropped.
+    """
+    windows = []
+    current: list | None = None
+
+    for item in items:
+        is_start = _eval_window_condition(start_when, item, context)
+
+        if end_when:
+            is_end = _eval_window_condition(end_when, item, context)
+
+            # A new start closes any open window (without the new item), then opens a fresh one
+            if is_start and current is not None:
+                windows.append(current)
+                current = None
+
+            if is_start:
+                current = [item]
+            elif current is not None:
+                current.append(item)
+
+            # Close the window if end fires (works even when start+end are the same item)
+            if is_end and current is not None:
+                windows.append(current)
+                current = None
+        else:
+            # No end_when: window runs until next start_when
+            if is_start:
+                if current is not None:
+                    windows.append(current)
+                current = [item]
+            elif current is not None:
+                current.append(item)
+
+    # Without end_when: last open window is closed by end-of-sequence and included.
+    # With end_when: an unclosed window (end_when never fired) is dropped.
+    if current is not None and end_when is None:
+        windows.append(current)
+    return windows
+
+
+def run_window_step(step: Dict[str, Any], context: Dict[str, Any], pipeline_config: Dict[str, Any]) -> str | None:
+    """Execute a window step — iterate over windows of the input list."""
+    input_data = resolve(step.get("input", []), context)
+    if not isinstance(input_data, list):
+        raise ValueError(
+            f"Window step '{step.get('name', 'unnamed')}': input must resolve to a list, "
+            f"got {type(input_data).__name__}"
+        )
+
+    item_var = step.get("item_var", "window")
+    steps = step.get("steps", [])
+    size = step.get("size")
+    stride = step.get("stride", size)  # default stride == size (tumbling)
+    include_partial = step.get("include_partial", True)
+    start_when = step.get("start_when")
+    end_when = step.get("end_when")
+
+    # Build window list
+    if start_when:
+        windows = _build_windows_condition(input_data, start_when, end_when, context)
+    else:
+        if not isinstance(size, int):
+            raise ValueError(
+                f"Window step '{step.get('name', 'unnamed')}': 'size' must be a positive integer"
+            )
+        if not isinstance(stride, int):
+            raise ValueError(
+                f"Window step '{step.get('name', 'unnamed')}': 'stride' must be a positive integer"
+            )
+        windows = _build_windows_fixed(input_data, size, stride, include_partial)
+
+    if not windows:
+        logger.info(f"⏭️  Window step '{step.get('name', 'unnamed')}': no windows generated, skipping")
+        return None
+
+    # Reuse for-each machinery — windows become the items
+    # Collect propagation targets
+    def collect_outputs(steps_list):
+        append_targets = set()
+        output_vars = set()
+        for s in steps_list:
+            if "append_to" in s:
+                append_targets.add(s["append_to"])
+            if "outputs" in s:
+                ov = s["outputs"]
+                if isinstance(ov, str):
+                    output_vars.add(ov)
+                elif isinstance(ov, list):
+                    output_vars.update(ov)
+            if "steps" in s:
+                na, no = collect_outputs(s["steps"])
+                append_targets.update(na)
+                output_vars.update(no)
+        return append_targets, output_vars
+
+    append_to_targets, output_vars = collect_outputs(steps)
+
+    for index, window in enumerate(windows, start=1):
+        iteration_context = deepcopy(context)
+        iteration_context[item_var] = window
+        iteration_context["_window_index"] = index
+        iteration_context["window_num"] = index   # condition-friendly alias (no leading _)
+        iteration_context["_window_first"] = window[0] if window else None
+        iteration_context["_window_last"] = window[-1] if window else None
+
+        # Maintain the for-each stack for debug filenames
+        parent_stack = iteration_context.get("_for_each_stack") or []
+        stack = [dict(frame) for frame in parent_stack] if parent_stack else []
+        new_frame = {
+            "level": len(stack) + 1,
+            "variable": item_var,
+            "value": f"window_{index}",
+            "label": f"window_{index}",
+            "index": index,
+        }
+        stack.append(new_frame)
+        iteration_context["_for_each_stack"] = stack
+        iteration_context["_for_each_meta"] = new_frame
+
+        for nested_step in steps:
+            after_action = run_step(nested_step, iteration_context, pipeline_config)
+
+            if after_action == "exit":
+                logger.info("🛑 'after: exit' in window iteration - exiting pipeline")
+                for target in append_to_targets:
+                    if target in iteration_context and isinstance(iteration_context[target], list):
+                        if target not in context:
+                            context[target] = iteration_context[target][:]
+                        else:
+                            orig = len(context[target])
+                            context[target].extend(iteration_context[target][orig:])
+                for output_var in output_vars:
+                    if output_var in iteration_context:
+                        context[output_var] = iteration_context[output_var]
+                return "exit"
+
+            elif after_action == "continue":
+                logger.info("⏭️  'after: continue' in window iteration - next window")
+                break
+
+        # Normal propagation
+        for target in append_to_targets:
+            if target in iteration_context and isinstance(iteration_context[target], list):
+                if target not in context:
+                    context[target] = iteration_context[target][:]
+                else:
+                    orig = len(context[target])
+                    context[target].extend(iteration_context[target][orig:])
+
+        for output_var in output_vars:
+            if output_var in iteration_context:
+                context[output_var] = iteration_context[output_var]
+
+    return None
 
 
 def run_if_step(step: Dict[str, Any], context: Dict[str, Any], pipeline_config: Dict[str, Any] | None = None) -> str | None:

--- a/src/llmflow/utils/linter.py
+++ b/src/llmflow/utils/linter.py
@@ -82,6 +82,11 @@ _EXTRA_STEP_KEYS = {
     "include_partial",
     "start_when",
     "end_when",
+    "size_by_tokens",
+    "stride_by_tokens",
+    "merge",
+    "item_var",
+    "over",
 }
 
 ALLOWED_STEP_KEYS = _SCHEMA_STEP_KEYS | _EXTRA_STEP_KEYS
@@ -1033,18 +1038,21 @@ def _lint_window_step(step: dict, errors: list) -> None:
     """Validate window step configuration."""
     name = step.get("name", "<unnamed>")
     has_size = "size" in step
+    has_size_by_tokens = "size_by_tokens" in step
     has_start_when = "start_when" in step
 
-    if not has_size and not has_start_when:
+    mode_count = sum([has_size, has_size_by_tokens, has_start_when])
+
+    if mode_count == 0:
         errors.append(
-            f"Window step '{name}': must specify either 'size' (fixed windows) "
-            f"or 'start_when' (condition-based windows)"
+            f"Window step '{name}': must specify one of 'size' (fixed), "
+            f"'size_by_tokens' (token-aware), or 'start_when' (condition-based)"
         )
         return
 
-    if has_size and has_start_when:
+    if mode_count > 1:
         errors.append(
-            f"Window step '{name}': 'size' and 'start_when' are mutually exclusive"
+            f"Window step '{name}': 'size', 'size_by_tokens', and 'start_when' are mutually exclusive"
         )
         return
 
@@ -1063,6 +1071,33 @@ def _lint_window_step(step: dict, errors: list) -> None:
                 f"Window step '{name}': 'end_when' is only valid with 'start_when', not 'size'"
             )
 
+        if "stride_by_tokens" in step:
+            errors.append(
+                f"Window step '{name}': 'stride_by_tokens' is only valid with 'size_by_tokens'"
+            )
+
+    if has_size_by_tokens:
+        sbt = step["size_by_tokens"]
+        if not isinstance(sbt, int) or sbt < 1:
+            errors.append(f"Window step '{name}': 'size_by_tokens' must be a positive integer")
+
+        if "stride_by_tokens" in step:
+            s = step["stride_by_tokens"]
+            if not isinstance(s, int) or s < 0:
+                errors.append(
+                    f"Window step '{name}': 'stride_by_tokens' must be a non-negative integer"
+                )
+
+        if "stride" in step:
+            errors.append(
+                f"Window step '{name}': use 'stride_by_tokens' (not 'stride') with 'size_by_tokens'"
+            )
+
+        if "end_when" in step or "start_when" in step:
+            errors.append(
+                f"Window step '{name}': 'start_when'/'end_when' cannot be used with 'size_by_tokens'"
+            )
+
     if has_start_when:
         if "stride" in step:
             errors.append(
@@ -1070,8 +1105,20 @@ def _lint_window_step(step: dict, errors: list) -> None:
             )
         if "include_partial" in step:
             errors.append(
-                f"Window step '{name}': 'include_partial' is only valid with 'size', not 'start_when'"
+                f"Window step '{name}': 'include_partial' is only valid with 'size' or 'size_by_tokens', not 'start_when'"
             )
+        if "stride_by_tokens" in step:
+            errors.append(
+                f"Window step '{name}': 'stride_by_tokens' is only valid with 'size_by_tokens'"
+            )
+
+    # Validate merge block
+    if "merge" in step:
+        merge = step["merge"]
+        if not isinstance(merge, dict):
+            errors.append(f"Window step '{name}': 'merge' must be a dict")
+        elif "function" not in merge:
+            errors.append(f"Window step '{name}': 'merge' must have a 'function' key")
 
     if "steps" not in step or not step["steps"]:
         errors.append(f"Window step '{name}': must have a non-empty 'steps' list")

--- a/src/llmflow/utils/linter.py
+++ b/src/llmflow/utils/linter.py
@@ -76,6 +76,12 @@ _EXTRA_STEP_KEYS = {
     "query_file",
     "params",
     "timeout",
+    # window step keys
+    "size",
+    "stride",
+    "include_partial",
+    "start_when",
+    "end_when",
 }
 
 ALLOWED_STEP_KEYS = _SCHEMA_STEP_KEYS | _EXTRA_STEP_KEYS
@@ -1023,6 +1029,54 @@ def _lint_conditional_rules(step, errors, key: str):
             if k not in {"if", "message"}:
                 errors.append(f"Step '{step.get('name','unnamed')}': unknown '{key}' key '{k}'")
 
+def _lint_window_step(step: dict, errors: list) -> None:
+    """Validate window step configuration."""
+    name = step.get("name", "<unnamed>")
+    has_size = "size" in step
+    has_start_when = "start_when" in step
+
+    if not has_size and not has_start_when:
+        errors.append(
+            f"Window step '{name}': must specify either 'size' (fixed windows) "
+            f"or 'start_when' (condition-based windows)"
+        )
+        return
+
+    if has_size and has_start_when:
+        errors.append(
+            f"Window step '{name}': 'size' and 'start_when' are mutually exclusive"
+        )
+        return
+
+    if has_size:
+        size = step["size"]
+        if not isinstance(size, int) or size < 1:
+            errors.append(f"Window step '{name}': 'size' must be a positive integer")
+
+        if "stride" in step:
+            stride = step["stride"]
+            if not isinstance(stride, int) or stride < 1:
+                errors.append(f"Window step '{name}': 'stride' must be a positive integer")
+
+        if "end_when" in step:
+            errors.append(
+                f"Window step '{name}': 'end_when' is only valid with 'start_when', not 'size'"
+            )
+
+    if has_start_when:
+        if "stride" in step:
+            errors.append(
+                f"Window step '{name}': 'stride' is only valid with 'size', not 'start_when'"
+            )
+        if "include_partial" in step:
+            errors.append(
+                f"Window step '{name}': 'include_partial' is only valid with 'size', not 'start_when'"
+            )
+
+    if "steps" not in step or not step["steps"]:
+        errors.append(f"Window step '{name}': must have a non-empty 'steps' list")
+
+
 def lint_pipeline_steps(steps):
     errors = []
     for step in steps:
@@ -1036,4 +1090,6 @@ def lint_pipeline_steps(steps):
                 errors.append(message)
         _lint_conditional_rules(step, errors, "require")
         _lint_conditional_rules(step, errors, "warn")
+        if step.get("type") == "window":
+            _lint_window_step(step, errors)
     return errors

--- a/src/llmflow/utils/linter.py
+++ b/src/llmflow/utils/linter.py
@@ -76,6 +76,8 @@ _EXTRA_STEP_KEYS = {
     "query_file",
     "params",
     "timeout",
+    # for-each parallel key
+    "parallel",
     # window step keys
     "size",
     "stride",
@@ -1124,6 +1126,64 @@ def _lint_window_step(step: dict, errors: list) -> None:
         errors.append(f"Window step '{name}': must have a non-empty 'steps' list")
 
 
+def _collect_var_refs(obj, refs: set | None = None) -> set:
+    """Recursively collect root variable names from all ${...} references in a config object."""
+    if refs is None:
+        refs = set()
+    if isinstance(obj, str):
+        for m in re.findall(r'\$\{([^}]+)\}', obj):
+            root = re.split(r'[.\[]', m.strip())[0]
+            refs.add(root)
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            _collect_var_refs(v, refs)
+    elif isinstance(obj, list):
+        for item in obj:
+            _collect_var_refs(item, refs)
+    return refs
+
+
+def _collect_loop_append_targets(steps_list: list) -> set:
+    """Recursively collect all append_to targets declared in a steps list."""
+    targets: set = set()
+    for s in steps_list:
+        if "append_to" in s:
+            targets.add(s["append_to"])
+        if "steps" in s and isinstance(s["steps"], list):
+            targets.update(_collect_loop_append_targets(s["steps"]))
+    return targets
+
+
+def _lint_for_each_parallel(step: dict, errors: list) -> None:
+    """Error when parallel: is set and a step reads an append_to target from the same loop.
+
+    In parallel mode every iteration starts from the same parent context snapshot —
+    append_to lists populated by other iterations are not visible during execution.
+    Reading such a variable within the loop produces an empty list (or the pre-loop
+    value) instead of the accumulated results, silently corrupting output.
+    """
+    parallel = step.get("parallel")
+    if not isinstance(parallel, int) or parallel <= 1:
+        return
+
+    name = step.get("name", "<unnamed>")
+    inner_steps = step.get("steps", [])
+    append_targets = _collect_loop_append_targets(inner_steps)
+    if not append_targets:
+        return
+
+    refs = _collect_var_refs(inner_steps)
+    cross = append_targets & refs
+    for target in sorted(cross):
+        errors.append(
+            f"Step '{name}': parallel: {parallel} is set but '${{{target}}}' is "
+            f"referenced within the loop — in parallel mode, append_to results are "
+            f"not visible to concurrent iterations (each iteration starts from the "
+            f"parent context snapshot). Remove the cross-iteration reference or use "
+            f"parallel: 1."
+        )
+
+
 def lint_pipeline_steps(steps):
     errors = []
     for step in steps:
@@ -1139,4 +1199,6 @@ def lint_pipeline_steps(steps):
         _lint_conditional_rules(step, errors, "warn")
         if step.get("type") == "window":
             _lint_window_step(step, errors)
+        if step.get("type") == "for-each":
+            _lint_for_each_parallel(step, errors)
     return errors

--- a/tests/test_parallel_for_each.py
+++ b/tests/test_parallel_for_each.py
@@ -1,0 +1,471 @@
+"""
+Tests for parallel: key on for-each steps.
+
+Covers:
+- Identical output to sequential execution (order preserved)
+- append_to accumulates in input order
+- outputs (last-wins) respects input order
+- First-exception propagates, cancels remaining work
+- after: exit propagates correctly
+- Linter error on cross-iteration append_to reference
+- Shared helper functions (_setup_iteration_context, _run_iteration_steps,
+  _propagate_iteration_results) used by both paths
+
+NO STUBS — uses real runner.py and linter.py.
+"""
+import sys
+import time
+import types
+import threading
+import pytest
+
+from llmflow.runner import (
+    run_for_each_step,
+    _collect_loop_outputs,
+    _setup_iteration_context,
+    _run_iteration_steps,
+    _propagate_iteration_results,
+)
+from llmflow.utils.linter import _lint_for_each_parallel, lint_pipeline_steps
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _register_fn(mod_name: str, **fns):
+    """Register functions in a temporary module; return cleanup callable."""
+    mod = types.ModuleType(mod_name)
+    for name, fn in fns.items():
+        setattr(mod, name, fn)
+    sys.modules[mod_name] = mod
+    return lambda: sys.modules.pop(mod_name, None)
+
+
+def _make_identity_step(mod_name: str, input_var: str, output_var: str, append_to: str | None = None):
+    """Return a step dict that passes input_var through to output_var (and optionally appends)."""
+    cleanup = _register_fn(mod_name, identity=lambda value: value)
+    step = {
+        "name": f"id_{output_var}",
+        "type": "function",
+        "function": f"{mod_name}.identity",
+        "inputs": {"value": f"${{{input_var}}}"},
+        "outputs": output_var,
+    }
+    if append_to:
+        step["append_to"] = append_to
+    return step, cleanup
+
+
+# ---------------------------------------------------------------------------
+# _collect_loop_outputs
+# ---------------------------------------------------------------------------
+
+class TestCollectLoopOutputs:
+
+    def test_collects_append_to_and_outputs(self):
+        steps = [
+            {"outputs": "foo", "append_to": "bar"},
+            {"outputs": ["baz", "qux"]},
+        ]
+        targets, vars_ = _collect_loop_outputs(steps)
+        assert targets == {"bar"}
+        assert vars_ == {"foo", "baz", "qux"}
+
+    def test_recursive_nested_steps(self):
+        steps = [
+            {"steps": [{"append_to": "inner_list", "outputs": "inner_var"}]},
+        ]
+        targets, vars_ = _collect_loop_outputs(steps)
+        assert "inner_list" in targets
+        assert "inner_var" in vars_
+
+
+# ---------------------------------------------------------------------------
+# _setup_iteration_context
+# ---------------------------------------------------------------------------
+
+class TestSetupIterationContext:
+
+    def test_item_var_set(self):
+        ctx = {"x": 1}
+        iter_ctx = _setup_iteration_context(1, "hello", ctx, "word", "step", None)
+        assert iter_ctx["word"] == "hello"
+
+    def test_for_each_index_set(self):
+        ctx = {}
+        iter_ctx = _setup_iteration_context(3, "a", ctx, "item", "step", None)
+        assert iter_ctx["_for_each_index"] == 3
+
+    def test_parent_context_not_mutated(self):
+        ctx = {"original": True}
+        _setup_iteration_context(1, "x", ctx, "item", "step", None)
+        assert "item" not in ctx
+
+    def test_stack_appended(self):
+        ctx = {}
+        iter_ctx = _setup_iteration_context(2, "val", ctx, "item", "my_step", None)
+        assert len(iter_ctx["_for_each_stack"]) == 1
+        assert iter_ctx["_for_each_stack"][0]["index"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _propagate_iteration_results
+# ---------------------------------------------------------------------------
+
+class TestPropagateIterationResults:
+
+    def test_append_to_extends_parent(self):
+        parent = {"results": [1, 2]}
+        iter_ctx = {"results": [1, 2, 3, 4]}  # items 3,4 added by iteration
+        _propagate_iteration_results(
+            iter_ctx, parent, {"results"}, set(), {"results": 2}
+        )
+        assert parent["results"] == [1, 2, 3, 4]
+
+    def test_append_to_creates_list_if_absent(self):
+        parent = {}
+        iter_ctx = {"results": ["a", "b"]}
+        _propagate_iteration_results(iter_ctx, parent, {"results"}, set(), {})
+        assert parent["results"] == ["a", "b"]
+
+    def test_output_var_propagated(self):
+        parent = {}
+        iter_ctx = {"last": "value"}
+        _propagate_iteration_results(iter_ctx, parent, set(), {"last"}, {})
+        assert parent["last"] == "value"
+
+    def test_only_new_items_propagated(self):
+        parent = {"items": ["pre"]}
+        iter_ctx = {"items": ["pre", "new1", "new2"]}
+        _propagate_iteration_results(
+            iter_ctx, parent, {"items"}, set(), {"items": 1}
+        )
+        assert parent["items"] == ["pre", "new1", "new2"]
+
+
+# ---------------------------------------------------------------------------
+# Parallel == sequential output (core invariant)
+# ---------------------------------------------------------------------------
+
+class TestParallelMatchesSequential:
+    """parallel: N must produce identical results to parallel: 1."""
+
+    def _run(self, items, parallel, mod_name):
+        cleanup = _register_fn(mod_name, double=lambda value: value * 2)
+        try:
+            context = {"items": items}
+            step = {
+                "name": "loop",
+                "type": "for-each",
+                "input": "${items}",
+                "item_var": "x",
+                "parallel": parallel,
+                "steps": [
+                    {
+                        "name": "do",
+                        "type": "function",
+                        "function": f"{mod_name}.double",
+                        "inputs": {"value": "${x}"},
+                        "outputs": "doubled",
+                        "append_to": "results",
+                    }
+                ],
+            }
+            run_for_each_step(step, context, {})
+            return context.get("results", [])
+        finally:
+            cleanup()
+
+    def test_order_preserved_parallel_3(self):
+        items = list(range(10))
+        seq = self._run(items, 1, "__par_seq_mod1")
+        par = self._run(items, 3, "__par_seq_mod2")
+        assert par == seq
+        assert par == [x * 2 for x in items]
+
+    def test_order_preserved_parallel_5(self):
+        items = list(range(20))
+        seq = self._run(items, 1, "__par_seq_mod3")
+        par = self._run(items, 5, "__par_seq_mod4")
+        assert par == seq
+
+    def test_outputs_last_wins_by_input_order(self):
+        """outputs (last-wins) uses last item in input order, not completion order."""
+        delays = {"__par_last_mod": None}
+        cleanup = _register_fn(
+            "__par_last_mod",
+            slow_identity=lambda value: value,
+        )
+        try:
+            context = {"items": ["first", "second", "third"]}
+            step = {
+                "name": "loop",
+                "type": "for-each",
+                "input": "${items}",
+                "item_var": "x",
+                "parallel": 3,
+                "steps": [
+                    {
+                        "name": "do",
+                        "type": "function",
+                        "function": "__par_last_mod.slow_identity",
+                        "inputs": {"value": "${x}"},
+                        "outputs": "last_seen",
+                    }
+                ],
+            }
+            run_for_each_step(step, context, {})
+            # "third" is last in input order — must win regardless of thread completion order
+            assert context["last_seen"] == "third"
+        finally:
+            cleanup()
+
+    def test_empty_input_no_results(self):
+        cleanup = _register_fn("__par_empty_mod", noop=lambda value: value)
+        try:
+            context = {"items": []}
+            step = {
+                "name": "loop",
+                "type": "for-each",
+                "input": "${items}",
+                "item_var": "x",
+                "parallel": 4,
+                "steps": [
+                    {
+                        "name": "do",
+                        "type": "function",
+                        "function": "__par_empty_mod.noop",
+                        "inputs": {"value": "${x}"},
+                        "outputs": "v",
+                        "append_to": "results",
+                    }
+                ],
+            }
+            run_for_each_step(step, context, {})
+            assert context.get("results", []) == []
+        finally:
+            cleanup()
+
+    def test_parallel_1_behaves_sequentially(self):
+        """parallel: 1 is equivalent to the default (no parallel key)."""
+        items = list(range(5))
+        cleanup1 = _register_fn("__par1_mod1", identity=lambda value: value)
+        cleanup2 = _register_fn("__par1_mod2", identity=lambda value: value)
+        try:
+            def _run(mod, parallel_val):
+                ctx = {"items": items}
+                s = {
+                    "name": "loop", "type": "for-each",
+                    "input": "${items}", "item_var": "x",
+                    "steps": [{
+                        "name": "do", "type": "function",
+                        "function": f"{mod}.identity",
+                        "inputs": {"value": "${x}"},
+                        "outputs": "v", "append_to": "results",
+                    }],
+                }
+                if parallel_val is not None:
+                    s["parallel"] = parallel_val
+                run_for_each_step(s, ctx, {})
+                return ctx["results"]
+
+            default = _run("__par1_mod1", None)
+            explicit1 = _run("__par1_mod2", 1)
+            assert default == explicit1 == items
+        finally:
+            cleanup1()
+            cleanup2()
+
+
+# ---------------------------------------------------------------------------
+# Parallel exception propagation
+# ---------------------------------------------------------------------------
+
+class TestParallelExceptionPropagation:
+
+    def test_exception_in_iteration_propagates(self):
+        def boom(value):
+            if value == 3:
+                raise RuntimeError("deliberate failure")
+            return value
+
+        cleanup = _register_fn("__par_exc_mod", boom=boom)
+        try:
+            context = {"items": list(range(6))}
+            step = {
+                "name": "loop",
+                "type": "for-each",
+                "input": "${items}",
+                "item_var": "x",
+                "parallel": 3,
+                "steps": [
+                    {
+                        "name": "do",
+                        "type": "function",
+                        "function": "__par_exc_mod.boom",
+                        "inputs": {"value": "${x}"},
+                        "outputs": "v",
+                    }
+                ],
+            }
+            with pytest.raises(RuntimeError, match="deliberate failure"):
+                run_for_each_step(step, context, {})
+        finally:
+            cleanup()
+
+
+# ---------------------------------------------------------------------------
+# after: exit in parallel mode
+# ---------------------------------------------------------------------------
+
+class TestParallelAfterExit:
+
+    def test_exit_from_iteration_propagates(self):
+        """after: exit in a parallel iteration returns 'exit' from the loop."""
+        cleanup = _register_fn("__par_exit_mod", identity=lambda value: value)
+        try:
+            context = {"items": [1, 2, 3]}
+            step = {
+                "name": "loop",
+                "type": "for-each",
+                "input": "${items}",
+                "item_var": "x",
+                "parallel": 3,
+                "steps": [
+                    {
+                        "name": "do",
+                        "type": "function",
+                        "function": "__par_exit_mod.identity",
+                        "inputs": {"value": "${x}"},
+                        "outputs": "v",
+                        "append_to": "results",
+                        "after": "exit",
+                    }
+                ],
+            }
+            result = run_for_each_step(step, context, {})
+            assert result == "exit"
+        finally:
+            cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Linter: cross-iteration append_to reference
+# ---------------------------------------------------------------------------
+
+class TestLintForEachParallel:
+
+    def _lint(self, step):
+        errors = []
+        _lint_for_each_parallel(step, errors)
+        return errors
+
+    def test_no_parallel_no_error(self):
+        step = {
+            "name": "loop", "type": "for-each", "input": "${items}",
+            "steps": [
+                {"outputs": "v", "append_to": "results"},
+                {"inputs": {"x": "${results}"}},
+            ],
+        }
+        assert self._lint(step) == []
+
+    def test_parallel_1_no_error(self):
+        step = {
+            "name": "loop", "type": "for-each", "input": "${items}",
+            "parallel": 1,
+            "steps": [
+                {"outputs": "v", "append_to": "results"},
+                {"inputs": {"x": "${results}"}},
+            ],
+        }
+        assert self._lint(step) == []
+
+    def test_parallel_cross_iteration_ref_is_error(self):
+        step = {
+            "name": "loop", "type": "for-each", "input": "${items}",
+            "parallel": 5,
+            "steps": [
+                {"outputs": "v", "append_to": "results"},
+                {"inputs": {"prior": "${results}"}},   # ← reads own append_to target
+            ],
+        }
+        errors = self._lint(step)
+        assert len(errors) == 1
+        assert "results" in errors[0]
+        assert "parallel" in errors[0]
+
+    def test_parallel_no_cross_ref_no_error(self):
+        step = {
+            "name": "loop", "type": "for-each", "input": "${items}",
+            "parallel": 5,
+            "steps": [
+                {"outputs": "v", "append_to": "results"},
+                {"inputs": {"other": "${parent_var}"}},  # reads parent, not results
+            ],
+        }
+        assert self._lint(step) == []
+
+    def test_multiple_cross_refs_multiple_errors(self):
+        step = {
+            "name": "loop", "type": "for-each", "input": "${items}",
+            "parallel": 3,
+            "steps": [
+                {"outputs": "a", "append_to": "list_a"},
+                {"outputs": "b", "append_to": "list_b"},
+                {"inputs": {"x": "${list_a}", "y": "${list_b}"}},
+            ],
+        }
+        errors = self._lint(step)
+        assert len(errors) == 2
+
+    def test_nested_cross_ref_detected(self):
+        step = {
+            "name": "loop", "type": "for-each", "input": "${items}",
+            "parallel": 4,
+            "steps": [
+                {"outputs": "v", "append_to": "results"},
+                {"steps": [{"inputs": {"x": "${results}"}}]},  # nested
+            ],
+        }
+        errors = self._lint(step)
+        assert any("results" in e for e in errors)
+
+    def test_lint_pipeline_steps_calls_for_each_lint(self):
+        """lint_pipeline_steps calls _lint_for_each_parallel for for-each steps."""
+        steps = [
+            {
+                "name": "bad_parallel",
+                "type": "for-each",
+                "input": "${items}",
+                "item_var": "x",
+                "parallel": 5,
+                "steps": [
+                    {"name": "a", "type": "function", "function": "f",
+                     "outputs": "v", "append_to": "acc"},
+                    {"name": "b", "type": "function", "function": "g",
+                     "inputs": {"prior": "${acc}"}},
+                ],
+            }
+        ]
+        errors = lint_pipeline_steps(steps)
+        assert any("acc" in e and "parallel" in e for e in errors)
+
+    def test_lint_pipeline_steps_valid_parallel_no_errors(self):
+        steps = [
+            {
+                "name": "ok_parallel",
+                "type": "for-each",
+                "input": "${items}",
+                "item_var": "x",
+                "parallel": 5,
+                "steps": [
+                    {"name": "a", "type": "function", "function": "f",
+                     "outputs": "v", "append_to": "acc"},
+                ],
+            }
+        ]
+        errors = lint_pipeline_steps(steps)
+        parallel_errors = [e for e in errors if "acc" in e and "parallel" in e]
+        assert parallel_errors == []

--- a/tests/test_window_step.py
+++ b/tests/test_window_step.py
@@ -1,0 +1,843 @@
+"""
+Tests for the window step type.
+
+Covers all three window strategies (tumbling, sliding, condition-based),
+include_partial behaviour, context variables, append_to propagation,
+and linter validation.
+
+NO STUBS — uses real runner.py and linter.py.
+"""
+import pytest
+from llmflow.runner import (
+    run_window_step,
+    _build_windows_fixed,
+    _build_windows_condition,
+)
+from llmflow.utils.linter import _lint_window_step
+
+
+# ---------------------------------------------------------------------------
+# _build_windows_fixed
+# ---------------------------------------------------------------------------
+
+class TestBuildWindowsFixed:
+
+    def test_tumbling_exact_fit(self):
+        items = list(range(6))
+        windows = _build_windows_fixed(items, size=2, stride=2, include_partial=True)
+        assert windows == [[0, 1], [2, 3], [4, 5]]
+
+    def test_tumbling_with_partial_included(self):
+        items = list(range(7))
+        windows = _build_windows_fixed(items, size=3, stride=3, include_partial=True)
+        assert windows == [[0, 1, 2], [3, 4, 5], [6]]
+
+    def test_tumbling_with_partial_excluded(self):
+        items = list(range(7))
+        windows = _build_windows_fixed(items, size=3, stride=3, include_partial=False)
+        assert windows == [[0, 1, 2], [3, 4, 5]]
+
+    def test_sliding_overlapping(self):
+        items = list(range(6))
+        windows = _build_windows_fixed(items, size=3, stride=1, include_partial=True)
+        assert windows == [
+            [0, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5],
+            [4, 5], [5],
+        ]
+
+    def test_sliding_partial_excluded(self):
+        items = list(range(6))
+        windows = _build_windows_fixed(items, size=3, stride=1, include_partial=False)
+        assert windows == [[0, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5]]
+
+    def test_sliding_stride_2(self):
+        items = list(range(8))
+        windows = _build_windows_fixed(items, size=4, stride=2, include_partial=True)
+        assert windows == [
+            [0, 1, 2, 3], [2, 3, 4, 5], [4, 5, 6, 7], [6, 7],
+        ]
+
+    def test_empty_input(self):
+        assert _build_windows_fixed([], size=3, stride=3, include_partial=True) == []
+
+    def test_size_larger_than_list_included(self):
+        items = [1, 2]
+        windows = _build_windows_fixed(items, size=5, stride=5, include_partial=True)
+        assert windows == [[1, 2]]
+
+    def test_size_larger_than_list_excluded(self):
+        items = [1, 2]
+        windows = _build_windows_fixed(items, size=5, stride=5, include_partial=False)
+        assert windows == []
+
+
+# ---------------------------------------------------------------------------
+# _build_windows_condition
+# ---------------------------------------------------------------------------
+
+class TestBuildWindowsCondition:
+
+    def _items(self, markers):
+        return [{"marker": m, "id": i} for i, m in enumerate(markers)]
+
+    def test_start_and_end_when(self):
+        items = self._items(["s", "a", "b", "e", "x", "s", "c", "e", "y"])
+        windows = _build_windows_condition(
+            items,
+            start_when="${item.marker == 's'}",
+            end_when="${item.marker == 'e'}",
+            context={},
+        )
+        assert len(windows) == 2
+        assert [it["marker"] for it in windows[0]] == ["s", "a", "b", "e"]
+        assert [it["marker"] for it in windows[1]] == ["s", "c", "e"]
+
+    def test_items_before_first_start_dropped(self):
+        items = self._items(["x", "y", "s", "a", "e"])
+        windows = _build_windows_condition(
+            items, start_when="${item.marker == 's'}",
+            end_when="${item.marker == 'e'}", context={},
+        )
+        assert len(windows) == 1
+        assert windows[0][0]["marker"] == "s"
+
+    def test_items_after_last_end_dropped(self):
+        items = self._items(["s", "a", "e", "x", "y"])
+        windows = _build_windows_condition(
+            items, start_when="${item.marker == 's'}",
+            end_when="${item.marker == 'e'}", context={},
+        )
+        assert len(windows) == 1
+        assert windows[0][-1]["marker"] == "e"
+
+    def test_no_end_when_closes_on_next_start(self):
+        items = self._items(["s", "a", "b", "s", "c", "d"])
+        windows = _build_windows_condition(
+            items, start_when="${item.marker == 's'}",
+            end_when=None, context={},
+        )
+        assert len(windows) == 2
+        assert [it["marker"] for it in windows[0]] == ["s", "a", "b"]
+        assert [it["marker"] for it in windows[1]] == ["s", "c", "d"]
+
+    def test_open_window_at_end_dropped_no_end_when(self):
+        # Without end_when, the last open window is included (it IS closed by end-of-sequence)
+        items = self._items(["s", "a", "b"])
+        windows = _build_windows_condition(
+            items, start_when="${item.marker == 's'}",
+            end_when=None, context={},
+        )
+        assert len(windows) == 1
+        assert [it["marker"] for it in windows[0]] == ["s", "a", "b"]
+
+    def test_new_start_before_end_closes_current(self):
+        # Two starts before any end: current window closed at second start
+        items = self._items(["s", "a", "s", "b", "e"])
+        windows = _build_windows_condition(
+            items, start_when="${item.marker == 's'}",
+            end_when="${item.marker == 'e'}", context={},
+        )
+        assert len(windows) == 2
+        assert [it["marker"] for it in windows[0]] == ["s", "a"]
+        assert [it["marker"] for it in windows[1]] == ["s", "b", "e"]
+
+    def test_empty_input(self):
+        assert _build_windows_condition([], "${item.x}", None, {}) == []
+
+
+# ---------------------------------------------------------------------------
+# run_window_step — integration via real runner
+# ---------------------------------------------------------------------------
+
+def _make_capture_step(capture_list_var: str, item_var: str) -> dict:
+    """A function step that appends the current window to a list."""
+    return {
+        "name": "capture",
+        "type": "function",
+        "function": "llmflow.utils.data.identity",
+        "inputs": {"value": f"${{{item_var}}}"},
+        "append_to": capture_list_var,
+    }
+
+
+class TestRunWindowStep:
+
+    def _run(self, step_config: dict, context: dict) -> dict:
+        run_window_step(step_config, context, {})
+        return context
+
+    def test_tumbling_basic(self):
+        context = {"items": list(range(6)), "results": []}
+        step = {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "batch",
+            "size": 2,
+            "steps": [
+                {
+                    "name": "record",
+                    "type": "function",
+                    "function": "llmflow.utils.data.identity",
+                    "inputs": {"value": "${batch}"},
+                    "append_to": "results",
+                }
+            ],
+        }
+        ctx = self._run(step, context)
+        assert ctx["results"] == [[0, 1], [2, 3], [4, 5]]
+
+    def test_tumbling_partial_included(self):
+        context = {"items": list(range(5)), "results": []}
+        step = {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "batch",
+            "size": 3,
+            "include_partial": True,
+            "steps": [
+                {
+                    "name": "record",
+                    "type": "function",
+                    "function": "llmflow.utils.data.identity",
+                    "inputs": {"value": "${batch}"},
+                    "append_to": "results",
+                }
+            ],
+        }
+        ctx = self._run(step, context)
+        assert ctx["results"] == [[0, 1, 2], [3, 4]]
+
+    def test_tumbling_partial_excluded(self):
+        context = {"items": list(range(5)), "results": []}
+        step = {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "batch",
+            "size": 3,
+            "include_partial": False,
+            "steps": [
+                {
+                    "name": "record",
+                    "type": "function",
+                    "function": "llmflow.utils.data.identity",
+                    "inputs": {"value": "${batch}"},
+                    "append_to": "results",
+                }
+            ],
+        }
+        ctx = self._run(step, context)
+        assert ctx["results"] == [[0, 1, 2]]
+
+    def test_sliding_windows(self):
+        context = {"items": list(range(5)), "results": []}
+        step = {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "batch",
+            "size": 3,
+            "stride": 1,
+            "include_partial": False,
+            "steps": [
+                {
+                    "name": "record",
+                    "type": "function",
+                    "function": "llmflow.utils.data.identity",
+                    "inputs": {"value": "${batch}"},
+                    "append_to": "results",
+                }
+            ],
+        }
+        ctx = self._run(step, context)
+        assert ctx["results"] == [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
+
+    def test_window_context_variables(self):
+        """_window_index, _window_first, _window_last are set per iteration."""
+        captured = []
+
+        def fake_emit(step, ctx, _cfg):
+            captured.append({
+                "index": ctx["_window_index"],
+                "first": ctx["_window_first"],
+                "last": ctx["_window_last"],
+            })
+
+        context = {"items": [10, 20, 30, 40]}
+        step = {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "batch",
+            "size": 2,
+            "steps": [],  # empty steps — we'll check context directly
+        }
+        # Patch steps to capture context mid-iteration
+        indices = []
+        firsts = []
+        lasts = []
+
+        import llmflow.runner as runner_mod
+        original_run_step = runner_mod.run_step
+
+        def capturing_run_step(step, ctx, cfg):
+            # Not called (steps is empty), but we need to verify context is set
+            pass
+
+        # Directly inspect by adding a thin recording step
+        records = []
+
+        def record_fn(value):
+            return value
+
+        step["steps"] = [
+            {
+                "name": "rec_index",
+                "type": "function",
+                "function": "llmflow.utils.data.identity",
+                "inputs": {"value": "${_window_index}"},
+                "append_to": "_indices",
+            },
+            {
+                "name": "rec_first",
+                "type": "function",
+                "function": "llmflow.utils.data.identity",
+                "inputs": {"value": "${_window_first}"},
+                "append_to": "_firsts",
+            },
+        ]
+        ctx = self._run(step, context)
+        assert ctx["_indices"] == [1, 2]   # _window_index via identity capture
+        assert ctx["_firsts"] == [10, 30]
+
+    def test_condition_based_windows(self):
+        items = [
+            {"marker": "s", "v": 1},
+            {"marker": "a", "v": 2},
+            {"marker": "e", "v": 3},
+            {"marker": "x", "v": 4},  # dropped — between windows
+            {"marker": "s", "v": 5},
+            {"marker": "e", "v": 6},
+        ]
+        context = {"items": items, "results": []}
+        step = {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "pericope",
+            "start_when": "${item.marker == 's'}",
+            "end_when": "${item.marker == 'e'}",
+            "steps": [
+                {
+                    "name": "record",
+                    "type": "function",
+                    "function": "llmflow.utils.data.identity",
+                    "inputs": {"value": "${pericope}"},
+                    "append_to": "results",
+                }
+            ],
+        }
+        ctx = self._run(step, context)
+        assert len(ctx["results"]) == 2
+        assert [it["v"] for it in ctx["results"][0]] == [1, 2, 3]
+        assert [it["v"] for it in ctx["results"][1]] == [5, 6]
+
+    def test_empty_input_no_error(self):
+        context = {"items": [], "results": []}
+        step = {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "batch",
+            "size": 3,
+            "steps": [
+                {
+                    "name": "record",
+                    "type": "function",
+                    "function": "llmflow.utils.data.identity",
+                    "inputs": {"value": "${batch}"},
+                    "append_to": "results",
+                }
+            ],
+        }
+        ctx = self._run(step, context)
+        assert ctx["results"] == []
+
+    def test_non_list_input_raises(self):
+        context = {"items": "not a list"}
+        step = {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "batch",
+            "size": 2,
+            "steps": [],
+        }
+        with pytest.raises(ValueError, match="must resolve to a list"):
+            run_window_step(step, context, {})
+
+
+# ---------------------------------------------------------------------------
+# Linter validation
+# ---------------------------------------------------------------------------
+
+class TestLintWindowStep:
+
+    def _lint(self, step: dict) -> list[str]:
+        errors = []
+        _lint_window_step(step, errors)
+        return errors
+
+    def test_valid_fixed_tumbling(self):
+        assert self._lint({"name": "w", "type": "window", "size": 3, "steps": [{}]}) == []
+
+    def test_valid_fixed_sliding(self):
+        assert self._lint({"name": "w", "type": "window", "size": 3, "stride": 1, "steps": [{}]}) == []
+
+    def test_valid_condition_based(self):
+        assert self._lint({
+            "name": "w", "type": "window",
+            "start_when": "${x}", "end_when": "${y}",
+            "steps": [{}],
+        }) == []
+
+    def test_valid_condition_no_end_when(self):
+        assert self._lint({
+            "name": "w", "type": "window",
+            "start_when": "${x}",
+            "steps": [{}],
+        }) == []
+
+    def test_missing_size_and_start_when(self):
+        errors = self._lint({"name": "w", "type": "window", "steps": [{}]})
+        assert any("size" in e and "start_when" in e for e in errors)
+
+    def test_size_and_start_when_both_present(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size": 3, "start_when": "${x}",
+            "steps": [{}],
+        })
+        assert any("mutually exclusive" in e for e in errors)
+
+    def test_stride_without_size(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "start_when": "${x}", "stride": 2,
+            "steps": [{}],
+        })
+        assert any("stride" in e for e in errors)
+
+    def test_end_when_without_start_when(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size": 3, "end_when": "${y}",
+            "steps": [{}],
+        })
+        assert any("end_when" in e for e in errors)
+
+    def test_include_partial_without_size(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "start_when": "${x}", "include_partial": False,
+            "steps": [{}],
+        })
+        assert any("include_partial" in e for e in errors)
+
+    def test_missing_steps(self):
+        errors = self._lint({"name": "w", "type": "window", "size": 3})
+        assert any("steps" in e for e in errors)
+
+    def test_empty_steps(self):
+        errors = self._lint({"name": "w", "type": "window", "size": 3, "steps": []})
+        assert any("steps" in e for e in errors)
+
+    def test_bad_size_type(self):
+        errors = self._lint({"name": "w", "type": "window", "size": "three", "steps": [{}]})
+        assert any("size" in e for e in errors)
+
+    def test_bad_stride_type(self):
+        errors = self._lint({"name": "w", "type": "window", "size": 3, "stride": 0, "steps": [{}]})
+        assert any("stride" in e for e in errors)
+
+    def test_lint_pipeline_steps_recognises_window(self):
+        """lint_pipeline_steps calls _lint_window_step for type: window steps."""
+        from llmflow.utils.linter import lint_pipeline_steps
+        steps = [
+            {
+                "name": "bad_window",
+                "type": "window",
+                "input": "${items}",
+                "item_var": "batch",
+                # Missing size AND start_when — should produce an error
+                "steps": [{"name": "x", "type": "function", "function": "f"}],
+            }
+        ]
+        errors = lint_pipeline_steps(steps)
+        assert any("size" in e and "start_when" in e for e in errors)
+
+    def test_lint_pipeline_steps_valid_window_no_errors(self):
+        from llmflow.utils.linter import lint_pipeline_steps
+        steps = [
+            {
+                "name": "valid_window",
+                "type": "window",
+                "input": "${items}",
+                "item_var": "batch",
+                "size": 3,
+                "steps": [{"name": "x", "type": "function", "function": "f"}],
+            }
+        ]
+        errors = lint_pipeline_steps(steps)
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# after: exit and after: continue inside window steps
+# ---------------------------------------------------------------------------
+
+class TestWindowFlowControl:
+
+    _record_step = {
+        "name": "record",
+        "type": "function",
+        "function": "llmflow.utils.data.identity",
+        "inputs": {"value": "${batch}"},
+        "append_to": "results",
+    }
+
+    def _base_step(self, nested):
+        return {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "batch",
+            "size": 2,
+            "steps": nested,
+        }
+
+    def test_after_exit_stops_iteration(self):
+        """after: exit on window 2 propagates out; window 3 never runs."""
+        context = {"items": list(range(6)), "results": []}
+
+        step = self._base_step([
+            self._record_step,
+            {
+                "name": "bail",
+                "type": "function",
+                "function": "llmflow.utils.data.identity",
+                "inputs": {"value": "${_window_index}"},
+                "outputs": "wi",
+                "condition": "window_num == 2",
+                "after": "exit",
+            },
+        ])
+
+        from llmflow.runner import run_window_step
+        action = run_window_step(step, context, {})
+
+        assert action == "exit"
+        # Windows 1 and 2 ran; window 3 did not
+        assert len(context["results"]) == 2
+        assert context["results"][0] == [0, 1]
+        assert context["results"][1] == [2, 3]
+
+    def test_after_continue_skips_remaining_steps_in_iteration(self):
+        """after: continue skips steps after it in that window, moves to next."""
+        context = {"items": list(range(6)), "results": [], "skipped": []}
+
+        step = self._base_step([
+            self._record_step,
+            {
+                "name": "skip_odd",
+                "type": "function",
+                "function": "llmflow.utils.data.identity",
+                "inputs": {"value": "${_window_index}"},
+                "outputs": "_skip_dummy",
+                "condition": "window_num == 2",
+                "after": "continue",
+            },
+            {
+                # This step runs on windows 1 and 3, but NOT window 2 (continue skips it)
+                "name": "after_skip",
+                "type": "function",
+                "function": "llmflow.utils.data.identity",
+                "inputs": {"value": "${_window_index}"},
+                "append_to": "ran_indices",
+            },
+        ])
+
+        from llmflow.runner import run_window_step
+        action = run_window_step(step, context, {})
+
+        assert action is None  # no exit
+        assert context["results"] == [[0, 1], [2, 3], [4, 5]]  # all windows recorded
+        # window_num 1 and 3 ran after_skip; window_num 2 was skipped by continue
+        assert context.get("ran_indices") == [1, 3]
+
+    def test_after_exit_propagates_accumulated_results(self):
+        """Results accumulated before exit are visible in context."""
+        context = {"items": list(range(8)), "results": []}
+
+        step = self._base_step([
+            self._record_step,
+            {
+                "name": "bail_at_3",
+                "type": "function",
+                "function": "llmflow.utils.data.identity",
+                "inputs": {"value": "0"},
+                "outputs": "_dummy",
+                "condition": "window_num == 3",
+                "after": "exit",
+            },
+        ])
+
+        from llmflow.runner import run_window_step
+        run_window_step(step, context, {})
+
+        # Windows 1, 2, 3 ran before exit
+        assert len(context["results"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Nested window and for-each combinations
+# ---------------------------------------------------------------------------
+
+class TestWindowNesting:
+
+    def test_window_inside_for_each(self):
+        """for-each over groups, window within each group."""
+        from llmflow.runner import run_step
+
+        groups = [list(range(4)), list(range(10, 14))]
+        context = {"groups": groups, "all_windows": []}
+
+        pipeline_step = {
+            "name": "outer",
+            "type": "for-each",
+            "input": "${groups}",
+            "item_var": "group",
+            "steps": [
+                {
+                    "name": "inner",
+                    "type": "window",
+                    "input": "${group}",
+                    "item_var": "win",
+                    "size": 2,
+                    "steps": [
+                        {
+                            "name": "record",
+                            "type": "function",
+                            "function": "llmflow.utils.data.identity",
+                            "inputs": {"value": "${win}"},
+                            "append_to": "all_windows",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        run_step(pipeline_step, context, {})
+
+        # Each group of 4 items → 2 windows of size 2
+        assert len(context["all_windows"]) == 4
+        assert context["all_windows"][0] == [0, 1]
+        assert context["all_windows"][1] == [2, 3]
+        assert context["all_windows"][2] == [10, 11]
+        assert context["all_windows"][3] == [12, 13]
+
+    def test_for_each_inside_window(self):
+        """window over a list, for-each within each window."""
+        from llmflow.runner import run_step
+
+        items = ["a", "b", "c", "d"]
+        context = {"items": items, "chars": []}
+
+        pipeline_step = {
+            "name": "outer",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "win",
+            "size": 2,
+            "steps": [
+                {
+                    "name": "inner",
+                    "type": "for-each",
+                    "input": "${win}",
+                    "item_var": "ch",
+                    "steps": [
+                        {
+                            "name": "record",
+                            "type": "function",
+                            "function": "llmflow.utils.data.identity",
+                            "inputs": {"value": "${ch}"},
+                            "append_to": "chars",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        run_step(pipeline_step, context, {})
+
+        assert context["chars"] == ["a", "b", "c", "d"]
+
+
+# ---------------------------------------------------------------------------
+# Condition-based windows with richer objects
+# ---------------------------------------------------------------------------
+
+class TestConditionWindowObjects:
+
+    def test_object_with_attribute_access(self):
+        """Items that are objects (not plain dicts) — dot notation via getattr."""
+        from types import SimpleNamespace
+        from llmflow.runner import _build_windows_condition
+
+        items = [
+            SimpleNamespace(type="heading", text="Title"),
+            SimpleNamespace(type="para", text="P1"),
+            SimpleNamespace(type="para", text="P2"),
+            SimpleNamespace(type="heading", text="Title2"),
+            SimpleNamespace(type="para", text="P3"),
+        ]
+
+        windows = _build_windows_condition(
+            items,
+            start_when="item.type == 'heading'",
+            end_when=None,
+            context={},
+        )
+
+        assert len(windows) == 2
+        assert windows[0][0].text == "Title"
+        assert len(windows[0]) == 3
+        assert windows[1][0].text == "Title2"
+        assert len(windows[1]) == 2
+
+    def test_condition_uses_parent_context(self):
+        """start_when can reference parent context variables."""
+        from llmflow.runner import _build_windows_condition
+
+        items = [
+            {"value": 1}, {"value": 5}, {"value": 2},
+            {"value": 10}, {"value": 3},
+        ]
+        # Window starts when item.value >= threshold (threshold from parent context)
+        windows = _build_windows_condition(
+            items,
+            start_when="item['value'] >= threshold",
+            end_when=None,
+            context={"threshold": 5},
+        )
+
+        assert len(windows) == 2
+        assert windows[0][0]["value"] == 5
+        assert windows[1][0]["value"] == 10
+
+    def test_condition_no_matches_returns_empty(self):
+        """If start_when never fires, no windows produced."""
+        from llmflow.runner import _build_windows_condition
+
+        items = [{"type": "para"}, {"type": "para"}]
+        windows = _build_windows_condition(
+            items,
+            start_when="item['type'] == 'heading'",
+            end_when=None,
+            context={},
+        )
+        assert windows == []
+
+    def test_single_item_window(self):
+        """A window can contain a single item."""
+        from llmflow.runner import _build_windows_condition
+
+        items = [{"s": True, "e": True}, {"s": False, "e": False}]
+        windows = _build_windows_condition(
+            items,
+            start_when="item['s']",
+            end_when="item['e']",
+            context={},
+        )
+        assert len(windows) == 1
+        assert len(windows[0]) == 1
+
+    def test_consecutive_start_markers_each_open_new_window(self):
+        """Two adjacent start markers without intervening items each form their own window."""
+        from llmflow.runner import _build_windows_condition
+
+        items = [
+            {"m": "s"}, {"m": "a"}, {"m": "e"},
+            {"m": "s"}, {"m": "e"},
+        ]
+        windows = _build_windows_condition(
+            items,
+            start_when="item['m'] == 's'",
+            end_when="item['m'] == 'e'",
+            context={},
+        )
+        assert len(windows) == 2
+        assert len(windows[0]) == 3
+        assert len(windows[1]) == 2
+
+
+# ---------------------------------------------------------------------------
+# outputs (last-window-wins) propagation
+# ---------------------------------------------------------------------------
+
+class TestWindowOutputPropagation:
+
+    def test_outputs_last_window_wins(self):
+        """Regular outputs follow last-window-wins semantics."""
+        context = {"items": list(range(6))}
+
+        step = {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "batch",
+            "size": 2,
+            "steps": [
+                {
+                    "name": "capture",
+                    "type": "function",
+                    "function": "llmflow.utils.data.identity",
+                    "inputs": {"value": "${batch}"},
+                    "outputs": "last_window",
+                }
+            ],
+        }
+
+        from llmflow.runner import run_window_step
+        run_window_step(step, context, {})
+
+        # Last window is [4, 5]
+        assert context["last_window"] == [4, 5]
+
+    def test_append_to_accumulates_all_windows(self):
+        """append_to collects results from every window."""
+        context = {"items": list(range(6)), "all": []}
+
+        step = {
+            "name": "w",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "batch",
+            "size": 2,
+            "steps": [
+                {
+                    "name": "capture",
+                    "type": "function",
+                    "function": "llmflow.utils.data.identity",
+                    "inputs": {"value": "${_window_index}"},
+                    "append_to": "all",
+                }
+            ],
+        }
+
+        from llmflow.runner import run_window_step
+        run_window_step(step, context, {})
+
+        assert context["all"] == [1, 2, 3]

--- a/tests/test_window_step.py
+++ b/tests/test_window_step.py
@@ -12,6 +12,7 @@ from llmflow.runner import (
     run_window_step,
     _build_windows_fixed,
     _build_windows_condition,
+    _build_windows_token,
 )
 from llmflow.utils.linter import _lint_window_step
 
@@ -841,3 +842,448 @@ class TestWindowOutputPropagation:
         run_window_step(step, context, {})
 
         assert context["all"] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# _build_windows_token
+# ---------------------------------------------------------------------------
+
+class TestBuildWindowsToken:
+    """Tests for token-aware windowing.
+
+    Uses a model that tiktoken supports (gpt-4o).  Each item is a short string
+    so we can reason about exact token counts.  A single ASCII word is typically
+    1 token in the cl100k / o200k encoding families.
+    """
+
+    MODEL = "gpt-4o"
+
+    def _words(self, n: int) -> list[str]:
+        """Return n single-token words."""
+        return [f"word{i}" for i in range(n)]
+
+    def test_tumbling_no_overlap(self):
+        """stride_by_tokens=0: non-overlapping windows."""
+        import tiktoken
+        enc = tiktoken.encoding_for_model(self.MODEL)
+        # Each "word0".."word2" is 1 token; 3-token windows
+        items = self._words(6)
+        tok_per_item = len(enc.encode(items[0]))  # typically 2 tokens: "word" + digit
+        size = tok_per_item * 3
+        windows = _build_windows_token(items, size_by_tokens=size, stride_by_tokens=0,
+                                       model=self.MODEL, include_partial=True)
+        assert len(windows) == 2
+        assert windows[0] == items[:3]
+        assert windows[1] == items[3:]
+
+    def test_sliding_overlap(self):
+        """stride_by_tokens > 0: last N token's-worth of items carry forward."""
+        import tiktoken
+        enc = tiktoken.encoding_for_model(self.MODEL)
+        items = self._words(6)
+        tok_per_item = len(enc.encode(items[0]))
+        size = tok_per_item * 3
+        stride = tok_per_item * 1  # 1 item of overlap
+        windows = _build_windows_token(items, size_by_tokens=size, stride_by_tokens=stride,
+                                       model=self.MODEL, include_partial=True)
+        # First window: items[0:3]; overlap = items[2]; next starts at items[2]
+        assert windows[0] == items[:3]
+        assert windows[1][0] == items[2]
+
+    def test_include_partial_true(self):
+        """Final short window is included when include_partial=True."""
+        import tiktoken
+        enc = tiktoken.encoding_for_model(self.MODEL)
+        items = self._words(5)
+        tok_per_item = len(enc.encode(items[0]))
+        size = tok_per_item * 3
+        windows = _build_windows_token(items, size_by_tokens=size, stride_by_tokens=0,
+                                       model=self.MODEL, include_partial=True)
+        # 5 items, 3 per window → [0-2], [3-4] (partial)
+        assert len(windows) == 2
+        assert len(windows[-1]) < 3
+
+    def test_include_partial_false(self):
+        """Final short window is dropped when include_partial=False."""
+        import tiktoken
+        enc = tiktoken.encoding_for_model(self.MODEL)
+        items = self._words(5)
+        tok_per_item = len(enc.encode(items[0]))
+        size = tok_per_item * 3
+        windows = _build_windows_token(items, size_by_tokens=size, stride_by_tokens=0,
+                                       model=self.MODEL, include_partial=False)
+        assert len(windows) == 1
+        assert windows[0] == items[:3]
+
+    def test_empty_input(self):
+        windows = _build_windows_token([], size_by_tokens=1000, stride_by_tokens=0,
+                                       model=self.MODEL, include_partial=True)
+        assert windows == []
+
+    def test_single_item_larger_than_size(self):
+        """An item exceeding size_by_tokens is included as a window of one."""
+        windows = _build_windows_token(
+            ["hello world " * 100],  # ~100+ tokens
+            size_by_tokens=1,
+            stride_by_tokens=0,
+            model=self.MODEL,
+            include_partial=True,
+        )
+        assert len(windows) == 1
+        assert len(windows[0]) == 1
+
+    def test_dict_items_serialised_as_json(self):
+        """Dict items are JSON-serialised for token counting."""
+        items = [{"verse": f"v{i}", "text": "lorem ipsum"} for i in range(4)]
+        windows = _build_windows_token(items, size_by_tokens=5000, stride_by_tokens=0,
+                                       model=self.MODEL, include_partial=True)
+        assert len(windows) >= 1
+        assert all(isinstance(item, dict) for w in windows for item in w)
+
+    def test_unknown_model_falls_back_to_cl100k(self):
+        """Unknown model name falls back to cl100k_base without error."""
+        items = self._words(4)
+        windows = _build_windows_token(items, size_by_tokens=1000, stride_by_tokens=0,
+                                       model="nonexistent-model-xyz", include_partial=True)
+        assert len(windows) == 1  # all fit in 1000 tokens
+
+    def test_no_infinite_loop_large_stride(self):
+        """stride_by_tokens >= window tokens still advances at least 1 item."""
+        import tiktoken
+        enc = tiktoken.encoding_for_model(self.MODEL)
+        items = self._words(4)
+        tok_per_item = len(enc.encode(items[0]))
+        size = tok_per_item * 2
+        stride = tok_per_item * 100  # larger than entire sequence
+        windows = _build_windows_token(items, size_by_tokens=size, stride_by_tokens=stride,
+                                       model=self.MODEL, include_partial=True)
+        # Should terminate; each window advances at least 1 item
+        assert len(windows) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Token window via run_window_step
+# ---------------------------------------------------------------------------
+
+class TestRunWindowStepToken:
+
+    def test_token_mode_produces_windows(self):
+        """run_window_step with size_by_tokens dispatches to token mode."""
+        import sys, types
+        mod = types.ModuleType("__tok_test_mod1")
+        mod.get_len = lambda items: len(items)
+        sys.modules["__tok_test_mod1"] = mod
+        try:
+            context: dict = {"verses": [f"verse {i}" for i in range(6)]}
+            step = {
+                "name": "tw",
+                "type": "window",
+                "input": "${verses}",
+                "item_var": "chunk",
+                "size_by_tokens": 5000,
+                "stride_by_tokens": 0,
+                "model": "gpt-4o",
+                "include_partial": True,
+                "steps": [
+                    {
+                        "name": "collect",
+                        "type": "function",
+                        "function": "__tok_test_mod1.get_len",
+                        "inputs": {"items": "${chunk}"},
+                        "outputs": "chunk_len",
+                        "append_to": "lens",
+                    }
+                ],
+            }
+            run_window_step(step, context, {})
+            assert "lens" in context
+            assert all(isinstance(x, int) for x in context["lens"])
+        finally:
+            sys.modules.pop("__tok_test_mod1", None)
+
+    def test_token_mode_item_var_in_context(self):
+        """item_var is exposed as the window list inside nested steps."""
+        captured = []
+
+        def _capture(**kwargs):
+            captured.append(kwargs.get("items"))
+            return None
+
+        import sys
+        import types
+        mod = types.ModuleType("_test_capture_mod")
+        mod.capture = _capture
+        sys.modules["_test_capture_mod"] = mod
+
+        context: dict = {"items": ["a", "b", "c", "d"]}
+        step = {
+            "name": "tw",
+            "type": "window",
+            "input": "${items}",
+            "item_var": "my_chunk",
+            "size_by_tokens": 5000,
+            "stride_by_tokens": 0,
+            "model": "gpt-4o",
+            "steps": [
+                {
+                    "name": "cap",
+                    "type": "function",
+                    "function": "_test_capture_mod.capture",
+                    "inputs": {"items": "${my_chunk}"},
+                }
+            ],
+        }
+        run_window_step(step, context, {})
+        assert len(captured) >= 1
+        assert all(isinstance(c, list) for c in captured)
+
+        del sys.modules["_test_capture_mod"]
+
+    def test_size_by_tokens_invalid_raises(self):
+        context: dict = {"v": ["x"]}
+        step = {
+            "name": "bad",
+            "type": "window",
+            "input": "${v}",
+            "size_by_tokens": -1,
+            "steps": [{}],
+        }
+        with pytest.raises(ValueError, match="size_by_tokens"):
+            run_window_step(step, context, {})
+
+    def test_over_alias_for_input(self):
+        """'over' is accepted as an alias for 'input'."""
+        import sys, types
+        mod = types.ModuleType("__over_alias_mod")
+        mod.get_len = lambda items: len(items)
+        sys.modules["__over_alias_mod"] = mod
+        try:
+            context: dict = {"items": [1, 2, 3]}
+            step = {
+                "name": "w",
+                "type": "window",
+                "over": "${items}",   # alias
+                "size": 2,
+                "include_partial": True,
+                "steps": [
+                    {
+                        "name": "noop",
+                        "type": "function",
+                        "function": "__over_alias_mod.get_len",
+                        "inputs": {"items": "${window}"},
+                        "outputs": "wlen",
+                        "append_to": "lens",
+                    }
+                ],
+            }
+            run_window_step(step, context, {})
+            assert "lens" in context
+        finally:
+            sys.modules.pop("__over_alias_mod", None)
+
+
+# ---------------------------------------------------------------------------
+# merge: block
+# ---------------------------------------------------------------------------
+
+class TestWindowMerge:
+
+    def _make_merge_fn(self, sys_mod_name="__merge_test_mod"):
+        """Register a merge function and return its full dotted name."""
+        import sys
+        import types
+        mod = types.ModuleType(sys_mod_name)
+
+        def merge_fn(items, label="merged"):
+            return {"merged": items, "label": label}
+
+        mod.merge_fn = merge_fn
+        sys.modules[sys_mod_name] = mod
+        return f"{sys_mod_name}.merge_fn", sys_mod_name
+
+    def test_merge_called_after_windows(self):
+        import sys, types
+        fn_path, mod_name = self._make_merge_fn("__merge_test_1")
+        # Register a helper that returns the window as a list
+        helper_mod = types.ModuleType("__merge_helper_1")
+        helper_mod.pass_through = lambda items: items
+        sys.modules["__merge_helper_1"] = helper_mod
+        try:
+            context: dict = {"items": [1, 2, 3, 4], "lbl": "test"}
+            step = {
+                "name": "w",
+                "type": "window",
+                "input": "${items}",
+                "size": 2,
+                "include_partial": True,
+                "steps": [
+                    {
+                        "name": "collect",
+                        "type": "function",
+                        "function": "__merge_helper_1.pass_through",
+                        "inputs": {"items": "${window}"},
+                        "outputs": "window_out",
+                        "append_to": "collected",
+                    }
+                ],
+                "merge": {
+                    "name": "merge_step",
+                    "function": fn_path,
+                    "inputs": {"items": "${collected}", "label": "${lbl}"},
+                    "outputs": "final",
+                },
+            }
+            run_window_step(step, context, {})
+            assert "final" in context
+            assert context["final"]["label"] == "test"
+        finally:
+            sys.modules.pop(mod_name, None)
+            sys.modules.pop("__merge_helper_1", None)
+
+    def test_merge_receives_full_accumulated_results(self):
+        import sys
+        import types
+        mod = types.ModuleType("__merge_test_2")
+        received = {}
+
+        def merge_fn(items):
+            received["items"] = items
+            return {"count": len(items)}
+
+        mod.merge_fn = merge_fn
+        sys.modules["__merge_test_2"] = mod
+
+        helper = types.ModuleType("__merge_helper_2")
+        helper.get_len = lambda items: len(items)
+        sys.modules["__merge_helper_2"] = helper
+
+        try:
+            context: dict = {"items": list(range(6))}
+            step = {
+                "name": "w",
+                "type": "window",
+                "input": "${items}",
+                "size": 2,
+                "include_partial": True,
+                "steps": [
+                    {
+                        "name": "noop",
+                        "type": "function",
+                        "function": "__merge_helper_2.get_len",
+                        "inputs": {"items": "${window}"},
+                        "outputs": "wl",
+                        "append_to": "wlens",
+                    }
+                ],
+                "merge": {
+                    "name": "merge",
+                    "function": "__merge_test_2.merge_fn",
+                    "inputs": {"items": "${wlens}"},
+                    "outputs": "summary",
+                },
+            }
+            run_window_step(step, context, {})
+            # 6 items / size 2 → 3 windows
+            assert received["items"] == [2, 2, 2]
+            assert context["summary"]["count"] == 3
+        finally:
+            sys.modules.pop("__merge_test_2", None)
+            sys.modules.pop("__merge_helper_2", None)
+
+
+# ---------------------------------------------------------------------------
+# Linter: size_by_tokens and merge
+# ---------------------------------------------------------------------------
+
+class TestLintWindowStepToken:
+
+    def _lint(self, step):
+        errors = []
+        _lint_window_step(step, errors)
+        return errors
+
+    def test_valid_size_by_tokens(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size_by_tokens": 25000,
+            "model": "gpt-4o",
+            "steps": [{}],
+        })
+        assert errors == []
+
+    def test_valid_size_by_tokens_with_stride(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size_by_tokens": 25000,
+            "stride_by_tokens": 5000,
+            "model": "gpt-4o",
+            "steps": [{}],
+        })
+        assert errors == []
+
+    def test_size_and_size_by_tokens_mutually_exclusive(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size": 3, "size_by_tokens": 1000,
+            "steps": [{}],
+        })
+        assert any("mutually exclusive" in e for e in errors)
+
+    def test_size_by_tokens_and_start_when_mutually_exclusive(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size_by_tokens": 1000, "start_when": "${x}",
+            "steps": [{}],
+        })
+        assert any("mutually exclusive" in e for e in errors)
+
+    def test_bad_size_by_tokens_type(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size_by_tokens": "big",
+            "steps": [{}],
+        })
+        assert any("size_by_tokens" in e for e in errors)
+
+    def test_bad_stride_by_tokens_negative(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size_by_tokens": 1000, "stride_by_tokens": -1,
+            "steps": [{}],
+        })
+        assert any("stride_by_tokens" in e for e in errors)
+
+    def test_stride_with_size_by_tokens_wrong_key(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size_by_tokens": 1000, "stride": 2,
+            "steps": [{}],
+        })
+        assert any("stride_by_tokens" in e for e in errors)
+
+    def test_valid_merge_block(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size": 3,
+            "steps": [{}],
+            "merge": {"function": "my.module.fn", "inputs": {}, "outputs": "result"},
+        })
+        assert errors == []
+
+    def test_merge_not_dict_raises(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size": 3,
+            "steps": [{}],
+            "merge": "just_a_string",
+        })
+        assert any("merge" in e for e in errors)
+
+    def test_merge_missing_function_key(self):
+        errors = self._lint({
+            "name": "w", "type": "window",
+            "size": 3,
+            "steps": [{}],
+            "merge": {"inputs": {}, "outputs": "result"},
+        })
+        assert any("merge" in e and "function" in e for e in errors)


### PR DESCRIPTION
## Summary

- Adds a new `window` step type to the LLMFlow pipeline language, analogous to XQuery window clauses
- Supports three modes: **fixed** (tumbling/sliding by item count), **condition** (`start_when`/`end_when` expressions), with token-based mode planned
- `include_partial` controls whether the final short window is emitted (default: `true`)
- Full linter validation for all window step keys

## Window step YAML syntax

```yaml
- name: chunk_paragraphs
  type: window
  over: ${paragraphs}
  size: 5          # items per window (fixed mode)
  stride: 5        # step size (stride < size = sliding; default = size = tumbling)
  include_partial: true
  steps:
    - name: summarize_chunk
      type: llm
      ...
      saveas: chunk_summary
  append_to: summaries
```

```yaml
- name: section_windows
  type: window
  over: ${items}
  start_when: "item.marker == 's'"   # condition mode (no ${} wrapper needed)
  end_when: "item.marker == 's'"
  steps:
    - ...
```

## Available context variables inside window steps

| Variable | Value |
|----------|-------|
| `window` | list of items in the current window |
| `window_num` | 1-based window index (condition-friendly, no underscore) |
| `window_size` | number of items in this window |

## Test plan

- [x] `TestBuildWindowsFixed` — 9 tests covering tumbling, sliding, partial, empty input
- [x] `TestBuildWindowsCondition` — 8 tests covering start/end conditions, open windows, edge cases
- [x] `TestRunWindowStep` — 8 integration tests via `run_window_step()`
- [x] `TestLintWindowStep` — 13 linter tests including valid steps and all error cases
- [x] `TestWindowFlowControl` — `after: exit`, `after: continue` inside windows
- [x] `TestWindowNesting` — window-in-for-each, for-each-in-window
- [x] `TestConditionWindowObjects` — SimpleNamespace items, parent context access
- [x] `TestWindowOutputPropagation` — last-window-wins, `append_to`
- [x] Full test suite: 1976 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)