### PR TITLE
chore: bump version to 0.2.1.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scripture-pipelines"
-version = "0.2.1.18"
+version = "0.2.1.19"
 description = "Declarative pipelines for LLM-powered workflows"
 authors = [{name = "Jonathan Robie", email = "jonathan.robie@gmail.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Bumps version to 0.2.1.19 in preparation for release

## Test plan

- [ ] Tests pass (auto-run on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)