### PR TITLE
Release 0.2.1.20 — single for/in loop syntax (breaking), fail-loud linter, doc-lint guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## 0.2.1.20 — 2026-07-06
 
-### Architecture
+### Breaking
+
+- **Loop syntax is now `for`/`in` only.** for-each and window steps use the XQuery-style
+  `for:` (loop variable) and `in:` (list) keys. The legacy aliases `item_var`/`input`/`over`/`as`
+  have been **removed** — the runtime raises and the linter flags them (with a "did you mean
+  'for'/'in'?" hint) rather than silently ignoring them. One syntax per language. Migrate
+  pipelines with `item_var:`→`for:`, `input:`/`over:`→`in:`.
 
 - **Step handlers extracted to `src/llmflow/steps/` package** — each step type now lives in
   its own module (`llm.py`, `function.py`, `for_each.py`, `window.py`, `if_step.py`,

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Scripture Pipelines operationalizes human authority through four interlocking di
 
 ## The Kairos Project
 
-Scripture Pipelines is at the heart of the **[Kairos Project](https://nida.org)**, a
+Scripture Pipelines is at the heart of the **[Kairos Project](https://nida.bible)**, a
 NIDA Institute initiative to build a global community of scholars — spanning the Western
 academy and far beyond it — who want to serve Bible translation and the global church.
 

--- a/docs/GPT_CONTEXT.md
+++ b/docs/GPT_CONTEXT.md
@@ -168,8 +168,8 @@ Loops over a list, executing nested steps for each item.
 ```yaml
 - name: process-items
   type: for-each
-  input: "${items}"           # List to iterate over
-  item_var: item              # Variable name for current item
+  for: item              # Variable name for current item
+  in: "${items}"           # List to iterate over
   steps:
     - name: process-one
       type: llm
@@ -226,8 +226,8 @@ Reads TSV (tab-separated values) files.
 ```yaml
 - name: process-rows
   type: for-each
-  input: "${rows}"
-  item_var: row
+  for: row
+  in: "${rows}"
   steps:
     - name: use-row-data
       type: llm
@@ -345,8 +345,8 @@ steps:
 
   - name: process-each
     type: for-each
-    input: "${items}"
-    item_var: item
+    for: item
+    in: "${items}"
     steps:
       - name: process-one
         type: llm
@@ -366,8 +366,8 @@ steps:
 steps:
   - name: check-status
     type: for-each
-    input: "${items}"
-    item_var: item
+    for: item
+    in: "${items}"
     steps:
       - name: process-if-active
         type: llm
@@ -390,8 +390,8 @@ steps:
 
   - name: process-entries
     type: for-each
-    input: "${entries}"
-    item_var: entry
+    for: entry
+    in: "${entries}"
     steps:
       - name: extract-data
         type: function
@@ -514,18 +514,18 @@ saveas: nonexistent/result.txt
 **Problem:** Loop not iterating correctly or items not accessible.
 
 **Solutions:**
-- Verify `input:` is a list (check previous step output)
+- Verify `in:` is a list (check previous step output)
 - Use correct syntax for item access (`${item}` or `${item[prop]}`)
 - For TSV: Use `${item[column_name]}` with brackets
-- Check `item_var:` doesn't conflict with existing variable
+- Check `for:` doesn't conflict with existing variable
 
 **Example:**
 ```yaml
 # ✅ Correct TSV access
 - name: process-rows
   type: for-each
-  input: "${rows}"
-  item_var: row
+  for: row
+  in: "${rows}"
   steps:
     - name: use-data
       type: echo
@@ -706,8 +706,8 @@ steps:
 
   - name: process-entries
     type: for-each
-    input: "${entries}"
-    item_var: entry
+    for: entry
+    in: "${entries}"
     steps:
       - name: expand-entry
         type: llm
@@ -747,8 +747,8 @@ steps:
 
   - name: process-each-entry
     type: for-each
-    input: "${entries}"
-    item_var: entry
+    for: entry
+    in: "${entries}"
     steps:
       - name: extract-lemma
         type: function
@@ -878,8 +878,8 @@ A: Prompts use `{{variable}}` syntax similar to Jinja2, but it's a simpler syste
 steps:
   - name: process-items
     type: for-each
-    input: "${items}"
-    item_var: item
+    for: item
+    in: "${items}"
     steps:
       - name: do-something
         type: llm
@@ -906,7 +906,8 @@ context = {"shared_list": ["initial"]}
 steps:
   - name: loop
     type: for-each
-    input: [1, 2, 3]
+    for: item
+    in: [1, 2, 3]
     steps:
       - name: modify-input
         type: function
@@ -932,7 +933,8 @@ steps:
 ```yaml
 - name: collect-results
   type: for-each
-  input: "${items}"
+  for: item
+  in: "${items}"
   steps:
     - name: process
       type: llm
@@ -972,13 +974,13 @@ steps:
 ```yaml
 - name: outer
   type: for-each
-  input: ["a", "b"]
-  item_var: outer_item
+  for: outer_item
+  in: ["a", "b"]
   steps:
     - name: inner
       type: for-each
-      input: [1, 2]
-      item_var: inner_item
+      for: inner_item
+      in: [1, 2]
       steps:
         - name: collect
           type: function

--- a/docs/ai-context/data-shapes.md
+++ b/docs/ai-context/data-shapes.md
@@ -77,7 +77,7 @@ Produced by an LLM step with `output_type: json`. The shape is defined by the pr
 ]
 ```
 
-Access in YAML: `${scene_list[0].Title}`, `${scene.Citation}`, `${scene.WLC}` (when `item_var: scene`).
+Access in YAML: `${scene_list[0].Title}`, `${scene.Citation}`, `${scene.WLC}` (when `for: scene`).
 
 **Note:** `${scene_list[*].Title}` is documented but **NOT YET IMPLEMENTED** — see the `[*]` section in `llmflow-language.md` and `tests/test_variable_resolution.py::TestStarWildcardResolution`.
 

--- a/docs/design/optional-parameters.md
+++ b/docs/design/optional-parameters.md
@@ -480,8 +480,8 @@ is documentation that the linter learns to verify.
 ```yaml
 - name: collect-analysis
   type: for-each
-  input: "${passages}"
-  item_var: item
+  for: item
+  in: "${passages}"
   steps:
     - name: analyze
       type: llm

--- a/docs/duckdb-analytics-design.md
+++ b/docs/duckdb-analytics-design.md
@@ -692,10 +692,11 @@ steps:
   # 2. Generate pedagogical descriptions
   - name: explain_verbs
     type: llm
-    prompt_file: prompts/explain_verbs.gpt
-    inputs:
-      verbs: "${verb_data}"
-      level: "intermediate"
+    prompt:
+      file: prompts/explain_verbs.gpt
+      inputs:
+        verbs: "${verb_data}"
+        level: "intermediate"
     outputs: vocab_list
 ```
 
@@ -778,11 +779,12 @@ steps:
   # 3. Generate pedagogical descriptions
   - name: explain_verbs
     type: llm
-    prompt_file: prompts/explain_verbs.gpt
-    inputs:
-      verbs: "${verb_data}"
-      collocations: "${collocation_data}"
-      level: "${level}"
+    prompt:
+      file: prompts/explain_verbs.gpt
+      inputs:
+        verbs: "${verb_data}"
+        collocations: "${collocation_data}"
+        level: "${level}"
     outputs: vocab_list
 
   # 4. Save to markdown

--- a/docs/llmflow-language-quickref.md
+++ b/docs/llmflow-language-quickref.md
@@ -121,8 +121,8 @@ Loops over a list variable and runs nested steps for each item.
 ```yaml
 - name: process_each_item
   type: for-each
-  input: "${items}"
-  item_var: item
+  for: item
+  in: "${items}"
   steps:
     - name: handle-item
       type: llm
@@ -134,8 +134,8 @@ Loops over a list variable and runs nested steps for each item.
       append_to: all_results
 ```
 
-- `input` points to a list value.
-- `item_var` is the name used to refer to each element.
+- `for` is the name used to refer to each element (XQuery-style: `for $x in $list`).
+- `in` points to the list value.
 - `${loop.index}`, `${loop.total}`, `${loop.first}`, `${loop.last}` are available inside every iteration.
 - Use `append_to` in nested steps to build a list across iterations.
 

--- a/docs/llmflow-language.md
+++ b/docs/llmflow-language.md
@@ -360,8 +360,8 @@ Loops over a list and executes substeps for each item.
 ```yaml
 - name: process_each_scene
   type: for-each
-  input: "${scene_list}"
-  item_var: scene
+  for: scene
+  in: "${scene_list}"
   steps:
     - name: bodies
       type: llm
@@ -375,9 +375,9 @@ Loops over a list and executes substeps for each item.
 ```
 
 **Required Fields:**
-- `input`: Variable name containing the list to iterate over
-- `item_var`: Variable name to bind each list item to
-- `steps`: Nested steps to execute for each item
+- `for`: Name bound to each list element (XQuery-style: `for $x in $list`)
+- `in`: The list to iterate over
+- `steps`: Nested steps to execute for each element
 
 **Using `append_to` in substeps:**
 Within `for-each` loops, use `append_to` to accumulate results across iterations:
@@ -385,8 +385,8 @@ Within `for-each` loops, use `append_to` to accumulate results across iterations
 ```yaml
 - name: process_each_scene
   type: for-each
-  input: "${scene_list}"
-  item_var: scene
+  for: scene
+  in: "${scene_list}"
   steps:
     - name: analyze_scene
       type: llm
@@ -412,8 +412,8 @@ Every iteration injects a `loop` dict into the step context:
 ```yaml
 - name: process_each_scene
   type: for-each
-  input: "${scene_list}"
-  item_var: scene
+  for: scene
+  in: "${scene_list}"
   steps:
     - name: log_progress
       type: function
@@ -422,13 +422,75 @@ Every iteration injects a `loop` dict into the step context:
         text: "Scene ${loop.index} of ${loop.total}"
 ```
 
-For nested `for-each` loops, the inner loop's `loop` variable shadows the outer one — consistent with how `item_var` works.
+For nested `for-each` loops, the inner loop's `loop` variable shadows the outer one — consistent with how the `for` variable works.
 
 **Important notes:**
 - Each iteration has its own isolated context
 - Variables from outer scope are accessible via `${var}`
 - Use `append_to` to collect results into a list variable
 - Nested `for-each` loops are supported
+
+**Optional modifiers** — reshape the list before iterating:
+
+| Field | Type | Effect |
+|---|---|---|
+| `order-by` | expression | Sort the list by this expression before iterating |
+| `group-by` | expression | Group iterations by this expression before processing |
+| `parallel` | integer | Number of iterations to run concurrently (default `1` = sequential); results are kept in input order |
+
+```yaml
+- name: analyze_pericopes
+  type: for-each
+  for: pericope
+  in: "${pericopes}"
+  order-by: "${pericope.sequence}"   # iterate in sequence order
+  parallel: 4                        # up to 4 iterations at once
+  steps:
+    - name: analyze
+      type: llm
+      prompt: { file: analyze.gpt, inputs: { p: "${pericope}" } }
+      outputs: analysis
+      append_to: analyses
+```
+
+---
+
+### type: `window`
+
+Groups a list into **windows** (sliding, tumbling, or condition-based) and runs substeps
+for each window. Like `for-each`, but each iteration binds a *list* of elements rather than a
+single item — useful for chunking long inputs (e.g. by token budget) before an LLM step.
+
+```yaml
+- name: chunk_verses
+  type: window
+  for: chunk               # binds each window (a list) to ${chunk}
+  in: "${verses}"          # the list to window over
+  size: 10                 # 10 elements per window
+  stride: 10               # advance 10 each time (tumbling); < size = sliding/overlap
+  steps:
+    - name: summarize_chunk
+      type: llm
+      prompt: { file: summarize.gpt, inputs: { verses: "${chunk}" } }
+      outputs: chunk_summary
+      append_to: summaries
+```
+
+**Fields:**
+
+| Field | Type | Meaning |
+|---|---|---|
+| `for` | string | Loop variable bound to each window — a *list* of elements. |
+| `in` | expression | The list to window over. |
+| `size` | integer | Fixed window size in elements. Omit to end windows dynamically via `!window_advance`. |
+| `stride` | integer | Elements to advance after each window. Default: same as `size` (tumbling); less than `size` = sliding. |
+| `include_partial` | boolean | Include a final window smaller than `size`. Default: `true`. |
+| `start_when` | expression | Begin a window when this evaluates true. |
+| `end_when` | expression | End a window when this evaluates true. Alternative to `!window_advance`. |
+| `size_by_tokens` | integer | Token-based window size instead of element count. Requires `model`. |
+| `stride_by_tokens` | integer | Token-based stride. Default: `0`. |
+| `model` | string | Model used for token counting when `size_by_tokens` is set. |
+| `steps` | array | Steps to execute for each window. |
 
 ---
 
@@ -556,6 +618,36 @@ Runs an XQuery against a local BaseX database via the `basex` CLI.
 - `saveas`: File path to save the output (supports `${var}` substitution).
 
 **Prerequisites:** The `basex` executable must be on `PATH` with a running BaseX instance.
+
+---
+
+### type: `duckdb`
+
+Runs a SQL query against an in-process DuckDB engine, registering context values as tables
+or parameters. Useful for joins, aggregation, and filtering over tabular data (e.g. rows
+from `load_csv`/`load_tsv`).
+
+```yaml
+- name: top-lemmas
+  type: duckdb
+  query: "SELECT lemma, COUNT(*) AS n FROM words GROUP BY lemma ORDER BY n DESC LIMIT 20"
+  # query_file: queries/top-lemmas.sql   # alternative: path to a .sql file
+  inputs:
+    words: "${morphology_rows}"   # registers the context list as a DuckDB table `words`
+  format: records                 # list of dicts (default)
+  output: top_lemmas
+```
+
+**Required Fields:**
+- `query` **or** `query_file` (exactly one)
+- `output` (or `outputs`): Variable name to store the result
+
+**Optional Fields:**
+- `inputs`: Map of table/parameter name → context key. Context values (e.g. `list[dict]`)
+  are registered as DuckDB tables so the query can reference them by name.
+- `format`: Output shape. `records` (default) returns a `list[dict]`.
+
+**Prerequisites:** the `duckdb` Python package (installed with LLMFlow).
 
 ---
 
@@ -829,8 +921,8 @@ steps:
   # Process each scene
   - name: process_each_scene
     type: for-each
-    input: "${scene_list}"
-    item_var: scene
+    for: scene
+    in: "${scene_list}"
     steps:
       - name: bodies
         type: llm

--- a/docs/xquery-greek-analytics.md
+++ b/docs/xquery-greek-analytics.md
@@ -429,10 +429,11 @@ steps:
   # 3. Generate pedagogical descriptions
   - name: explain_patterns
     type: llm
-    prompt_file: prompts/explain_syntax_patterns.gpt
-    inputs:
-      patterns: "${patterns_data}"
-      book: "${book}"
+    prompt:
+      file: prompts/explain_syntax_patterns.gpt
+      inputs:
+        patterns: "${patterns_data}"
+        book: "${book}"
     outputs: syntax_guide
 
   # 4. Save output

--- a/project/RELEASE_CHECKLIST.md
+++ b/project/RELEASE_CHECKLIST.md
@@ -2,217 +2,217 @@
 
 Follow this checklist when preparing a new release.
 
-**For AI assistance:** Invoke the `/release` skill which provides guided automation and mandatory verification.
+## The model (read this first)
 
-**CRITICAL:** Never claim "build succeeded" without running verification commands. See Section 8 for mandatory checks.
+As of 0.2.1.20 the release pipeline is **build-on-PR, promote-on-tag** — see
+`project/plans/design-pr-build-promote.md` for the full design.
+
+- **`build.yml`** runs on every **pull request**: tests + the Linux/macOS/Windows Nuitka
+  builds, uploading the three binaries as artifacts (7-day retention). This is the merge
+  gate — a red build blocks merge.
+- **`release.yml`** runs on a **`v*` tag**: it does **NOT rebuild**. It finds the successful
+  `build.yml` run for the tagged commit, downloads those exact binaries, attaches them to a
+  GitHub Release, publishes, verifies the install scripts, and publishes the wheel to PyPI.
+
+**Consequences that differ from the old flow:**
+- The binaries are already built *before* you tag. Tagging promotes them.
+- The tag **must point at the merge commit** whose `HEAD^2` is the PR head that was built.
+- You must merge with a **merge commit** (not squash/rebase), or there is no `HEAD^2` to
+  resolve and `release.yml` fails.
+- Blessed artifacts expire after **7 days** — tag within that window or the build re-runs.
+
+**CRITICAL:** Never claim "release succeeded" without watching `release.yml` to completion.
+See Section 8.
 
 ---
 
 ## Pre-Release Validation
 
-### 1. Test Suite
-- [ ] `pytest -v` passes with 0 failures
-- [ ] Check test count hasn't decreased unexpectedly
-- [ ] Review any newly skipped tests (should be rare)
-- [ ] Integration tests pass (or are properly skipped if API keys absent)
-- [ ] GitHub Actions test workflow passing on dev branch
+### 1. The PR build is green
+- [ ] The release PR (dev → main) has a passing **`build.yml`** run on its head commit
+- [ ] All three platforms succeeded — verify explicitly:
+  ```bash
+  gh run list --workflow build.yml --limit 1 --json headSha,conclusion
+  gh run view <run-id> --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
+  ```
+- [ ] Tests job green (integration tests are deselected in CI via `-m "not integration"`)
 
-**Note:** Tests verify code correctness. This is NOT the same as Nuitka executable builds.
+**Note:** the build already happened here, on the PR — not at tag time. If this is red, fix
+it before merging; do not tag hoping the release build will differ.
 
-### 2. Previous Nuitka Build Status
-- [ ] Check if previous Nuitka builds are failing: `gh run list --workflow=build-release.yml --limit 3`
-- [ ] If previous builds failed, understand why before creating new tag
-- [ ] Recent successful Nuitka build completed (if one exists)
-- [ ] Binary sizes reasonable (~50-70MB range) in last successful build
-
-**Note:** Nuitka builds create executables (sp-linux, sp-macos, sp-windows.exe). This is NOT the same as pytest.
+### 2. Blessed artifacts exist and are fresh
+- [ ] The PR build uploaded `sp-linux`, `sp-macos`, `sp-windows.exe`:
+  ```bash
+  gh api repos/nida-institute/LLMFlow/actions/runs/<run-id>/artifacts \
+    --jq '.artifacts[] | "\(.name)  \(.size_in_bytes) bytes  expires \(.expires_at[0:10])"'
+  ```
+- [ ] Expiry is in the future (7-day retention) — you must tag before then
+- [ ] Binary sizes reasonable (~95–145 MB each)
 
 ### 3. Version & Changelog
-- [ ] `CHANGELOG.md` updated with all changes from this release
-  - Clear section with version number and date
-  - Categorized changes (features, fixes, docs, etc.)
-  - Issue numbers linked where applicable
-  - Breaking changes clearly marked (if any)
-- [ ] Version number incremented in `pyproject.toml`
-  - **Convention:** Always bump 4th component (e.g., 0.2.1.04 → 0.2.1.05)
-  - Unless explicitly bumping minor/major
+- [ ] `CHANGELOG.md` has a section for this version (date, categorized changes, issue refs,
+      breaking changes marked)
+- [ ] Version bumped in `pyproject.toml` — **bump the 4th component** (e.g. 0.2.1.19 → 0.2.1.20)
+      unless explicitly doing a minor/major
+- [ ] The version-bump commit is part of the PR (so the tag lands on code with the right version)
 
-### 4. Documentation Sync
-- [ ] AI context files up to date (docs/ai-context/)
-- [ ] Main documentation reflects new features (docs/*.md)
-- [ ] INSTALL.md still accurate for current release
-- [ ] README.md examples still work
-- [ ] Tutorial still matches current CLI behavior
+### 4. Documentation sync
+- [ ] Main docs reflect new features (`docs/*.md`, e.g. `docs/llmflow-language.md`)
+- [ ] `INSTALL.md` / `README.md` examples still accurate
+- [ ] Tutorial matches current CLI behavior
+- [ ] (Propose updates to `docs/ai-context/` to the Captain if the workflow changed — do not
+      edit those directly)
 
-### 5. Code Quality
-- [ ] No TODO/FIXME comments that should be addressed before release
-- [ ] No debug print statements left in production code
-- [ ] No commented-out code blocks that should be removed
-- [ ] Linter passes (`llmflow lint` on example pipelines)
+### 5. Code quality
+- [ ] No stray debug prints / commented-out blocks that should go
+- [ ] `sp lint` passes on example pipelines
+- [ ] No consumer-specific coupling introduced into the core engine
+      (see `project/audits/` cruft audit)
 
 ---
 
 ## Release Process
 
-### 6. Branch Management
-- [ ] All changes committed on dev branch
-- [ ] `git push origin dev` completed
-- [ ] Switch to main: `git checkout main`
-- [ ] Merge dev: `git merge dev --no-edit`
-- [ ] Resolve any merge conflicts
-- [ ] `git push origin main`
+### 6. Merge the PR — **must be a merge commit**
+- [ ] The PR is up to date with `main` (no divergence)
+- [ ] Merge with a **merge commit** so `release.yml` can resolve `HEAD^2`:
+  ```bash
+  gh pr merge <pr-number> --merge --repo nida-institute/LLMFlow
+  ```
+  **Do NOT** use `--squash` or `--rebase` (they destroy the `HEAD^2` mapping).
+  **Do NOT** use `--delete-branch` (the head branch is `dev`).
+- [ ] Confirm the merge commit's second parent is the built PR head:
+  ```bash
+  git fetch origin main
+  git rev-list --parents -n1 origin/main   # third SHA = HEAD^2 = the built commit
+  ```
 
-### 7. Tagging **[CRITICAL - CHECK FOR EXISTING TAGS]**
+### 7. Tagging **[CRITICAL — TAG THE MERGE COMMIT, DELETE STALE TAGS FIRST]**
+
+> ⚠️ Incident (2026-07-11): a pre-existing local `v0.2.1.20` tag caused `git tag` to fail
+> silently; the stale tag (pointing at the old version-bump commit) got pushed instead,
+> firing the retired workflow on stale code. **Always delete any existing tag first, and
+> verify the tag dereferences to the merge commit before pushing.**
 
 ```bash
-# Get version from pyproject.toml
-VERSION=$(grep 'version = ' pyproject.toml | cut -d'"' -f2)
+VERSION=$(grep '^version' pyproject.toml | head -1 | cut -d'"' -f2)
+MERGE=$(git rev-parse origin/main)          # the merge commit
 
-# CHECK if tag already exists (prevents orphaned tags from failed releases)
-git tag --list "v$VERSION"
-git ls-remote --tags origin "v$VERSION"
+# Delete any existing tag (local + remote) — prevents the silent-stale-tag trap
+git tag -d "v$VERSION" 2>/dev/null || true
+git push origin ":refs/tags/v$VERSION" 2>/dev/null || true
 
-# If tag exists, DELETE IT FIRST:
-git tag -d "v$VERSION"
-git push origin --delete "v$VERSION"
+# Create the annotated tag ON THE MERGE COMMIT
+git tag -a "v$VERSION" "$MERGE" -m "Release $VERSION"
 
-# Create new annotated tag
-git tag -a "v$VERSION" -m "Release $VERSION"
+# VERIFY it points at the merge commit (annotated tags: use ^{commit})
+git rev-parse "v$VERSION^{commit}"          # must equal $MERGE
+git rev-list --parents -n1 "v$VERSION^{commit}"   # third SHA = built PR head
 
-# Push tag to trigger build
 git push origin "v$VERSION"
 ```
 
 **CHECKLIST:**
-- [ ] Checked for existing tag with same version number
-- [ ] Deleted old tag if it existed (locally and remotely)
-- [ ] Created annotated tag: `git tag -a v$VERSION -m "Release $VERSION"`
-  - Use exact version from pyproject.toml
-  - Format: `v` + version number (e.g., v0.2.1.15)
-- [ ] Pushed tag: `git push origin v$VERSION`
-- [ ] Verified tag appears on GitHub: https://github.com/nida-institute/LLMFlow/tags
+- [ ] Deleted any existing `v$VERSION` tag locally and remotely
+- [ ] Created annotated tag on the **merge commit** (not the version-bump commit)
+- [ ] `v$VERSION^{commit}` equals the merge commit SHA
+- [ ] `HEAD^2` of that commit is the PR head that `build.yml` built
+- [ ] Pushed the tag
 
-### 8. CI Build **[CRITICAL - MANDATORY VERIFICATION]**
-
-**🚨 DO NOT SKIP THESE VERIFICATION COMMANDS 🚨**
+### 8. Watch `release.yml` **[MANDATORY VERIFICATION]**
 
 ```bash
-# Wait for workflow to start (30 seconds after tag push)
-sleep 30
-
-# Check if workflow was triggered
-gh run list --workflow=build-release.yml --limit 1
-
-# Get the run ID and URL
-RUN_ID=$(gh run list --workflow=build-release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
-echo "Build URL: https://github.com/nida-institute/LLMFlow/actions/runs/$RUN_ID"
-
-# Monitor until complete (takes ~3-5 minutes)
-gh run watch $RUN_ID
-
-# VERIFY ALL PLATFORMS SUCCEEDED (all must show "success")
-gh run view $RUN_ID --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
+sleep 15
+RUN=$(gh run list --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN" --exit-status
+gh run view "$RUN" --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
 ```
 
-**CHECKLIST (do not proceed unless ALL are checked):**
-- [ ] GitHub Actions "Build and Release Executables" workflow triggered automatically
-- [ ] Verified run URL in browser shows ALL green checkmarks
-- [ ] Command output shows "success" for: Create Draft Release, Build on Linux, Build on macOS, Build on Windows
-- [ ] Draft release created automatically
-- [ ] Binaries attached to release (visible in GitHub UI):
-  - `sp-linux`
-  - `sp-macos`
-  - `sp-windows.exe`
-- [ ] Binary sizes reasonable (~50-70MB each)
+**CHECKLIST (do not claim success unless ALL pass):**
+- [ ] The **Release** workflow (not the old "Build and Release Executables") triggered, on
+      the merge-commit SHA
+- [ ] `resolve-build` found the build run (if it fails here: the tag isn't on the merge
+      commit, or artifacts expired — it fails loud, nothing is published)
+- [ ] `create-release` → `promote` attached all three binaries (no rebuild)
+- [ ] `publish-release` flipped the draft to published
+- [ ] `verify-install` passed on all three OSes
+- [ ] `publish-pypi` succeeded — confirm at https://pypi.org/project/scripture-pipelines/
+- [ ] Release assets present: `sp-linux`, `sp-macos`, `sp-windows.exe`
+  ```bash
+  gh release view "v$VERSION" --json isDraft,assets --jq '{isDraft, assets:[.assets[].name]}'
+  ```
 
-**IF ANY BUILD FAILED:**
+**IF `release.yml` FAILS:** it never publishes a partial/bad release. Diagnose, then:
 ```bash
-# Get error logs
-gh run view $RUN_ID --log-failed
-
-# Delete failed release and tag
-gh release delete "v$VERSION" --yes
-git tag -d "v$VERSION"
-git push origin --delete "v$VERSION"
-
-# Fix the issue, then start checklist over from step 1
+gh run view "$RUN" --log-failed
+gh release delete "v$VERSION" --yes 2>/dev/null || true   # if a draft was created
+git tag -d "v$VERSION"; git push origin ":refs/tags/v$VERSION"
+# fix, re-merge if needed, re-tag from Section 7
 ```
 
-### 9. Release Notes
-- [ ] Open draft release on GitHub
-- [ ] Review auto-generated notes
-- [ ] Edit release notes for clarity
-  - Add highlights section for major features
-  - Note any breaking changes prominently
-  - Link to CHANGELOG for full details
-  - Add migration notes if needed
-- [ ] Verify binary download links work
-- [ ] Publish release (convert from draft)
+### 9. Release notes
+- [ ] Review the auto-generated notes on the published release
+- [ ] Add a highlights section; call out breaking changes; link `CHANGELOG.md`
+- [ ] Verify the binary download links work
 
 ---
 
 ## Post-Release Validation
 
-### 10. Installation Testing
-- [ ] Download Linux binary, verify `chmod +x`, test `./sp-linux --version`
-- [ ] Download macOS binary, verify Gatekeeper instructions in INSTALL.md work
-- [ ] Download Windows binary, verify SmartScreen instructions work
-- [ ] Test `sp init` workflow on fresh directory
-- [ ] Test example pipeline runs
+### 10. Installation testing
+- [ ] `install.sh` (Linux/macOS) and `install.ps1` (Windows) install a runnable `sp`
+      (largely covered by the `verify-install` job, but spot-check once)
+- [ ] `pip install scripture-pipelines` gets the new version
+- [ ] `sp init` on a fresh directory works; an example pipeline runs
 
-### 11. Documentation Updates
-- [ ] Update any external documentation pointing to release downloads
-- [ ] Update version references in docs (if they specify versions)
-- [ ] Announce release (if there's a communication plan)
+### 11. Documentation & announcement
+- [ ] Update any external docs pointing at release downloads
+- [ ] Announce (if there's a communication plan)
 
-### 12. Branch Cleanup
-- [ ] Switch back to dev: `git checkout dev`
-- [ ] Reset CHANGELOG "Unreleased" section:
-  ```markdown
-  ## Unreleased
-  - _No changes yet._
-  ```
-- [ ] Commit and push to dev
+### 12. Prepare `dev` for the next cycle
+- [ ] `git checkout dev && git pull`
+- [ ] Bump `pyproject.toml` to the next 4th-component version
+- [ ] Start a fresh `CHANGELOG.md` section for the next release
+- [ ] Commit and push to `dev`
 
 ---
 
-## Rollback Procedure
+## Rollback
 
-If a critical issue is discovered post-release:
-
-1. Mark release as "pre-release" on GitHub (or delete it)
-2. Remove binaries from release assets
-3. Delete the tag locally: `git tag -d v0.2.1.05`
-4. Delete the tag remotely: `git push origin :refs/tags/v0.2.1.05`
-5. Fix the issue on dev branch
-6. Follow checklist again for new release
+If a critical issue is found post-release:
+1. Mark the GitHub release as pre-release (or delete it)
+2. Yank the PyPI release if the wheel is broken (`pip` users are affected):
+   see https://pypi.org/help/#yanked
+3. Delete the tag: `git tag -d vX; git push origin :refs/tags/vX`
+4. Fix on `dev`, open a PR (rebuilds on the PR), then re-release from Section 6
 
 ---
 
-## Version Numbering Convention
+## Common failure modes (learned the hard way)
 
-**Always increment the 4th component** (per user-prefs.md):
-- `0.2.1.02` → `0.2.1.03` → `0.2.1.04` → `0.2.1.05`
-- Never propose minor/major bump unless explicitly asked
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `release.yml` didn't run; old "Build and Release Executables" did | Tag points at a pre-CI-split commit | Tag the **merge commit**; delete the stale tag first |
+| `git tag` "already exists", stale tag pushed | Didn't delete the existing tag first | Always `git tag -d` + delete remote before re-tagging (Section 7) |
+| `resolve-build` fails, no release | Squash/rebase merge (no `HEAD^2`), or tag not on merge commit, or artifacts expired | Merge-commit only; tag the merge commit; tag within 7 days |
+| PyPI publishes but binaries missing | (shouldn't happen — `publish-pypi` needs `promote`) | Check the job graph in `release.yml` |
 
-## Quick Reference: Common Commands
+## Version numbering
+- Always increment the **4th component** (`0.2.1.19` → `0.2.1.20`). Never propose minor/major
+  unless explicitly asked.
 
+## Quick reference (happy path)
 ```bash
-# Run tests
-pytest -v
-
-# Check version in pyproject.toml
-grep 'version =' pyproject.toml
-
-# Create and push tag
-git tag -a v0.2.1.05 -m "Release 0.2.1.05"
-git push origin v0.2.1.05
-
-# Quick release (assumes all checks passed)
-git checkout main && \
-git merge dev --no-edit && \
-git push origin main && \
-git tag -a v0.2.1.05 -m "Release 0.2.1.05" && \
-git push origin v0.2.1.05 && \
-git checkout dev
+# 1. Confirm the PR build is green (Section 1) and artifacts are fresh (Section 2)
+# 2. Merge as a merge commit
+gh pr merge <pr-number> --merge --repo nida-institute/LLMFlow
+# 3. Tag the merge commit (delete any stale tag first)
+git fetch origin main
+VERSION=$(grep '^version' pyproject.toml | head -1 | cut -d'"' -f2)
+git tag -d "v$VERSION" 2>/dev/null; git push origin ":refs/tags/v$VERSION" 2>/dev/null
+git tag -a "v$VERSION" "$(git rev-parse origin/main)" -m "Release $VERSION"
+git rev-parse "v$VERSION^{commit}"    # sanity: == origin/main
+git push origin "v$VERSION"
+# 4. Watch the release (Section 8)
+gh run watch "$(gh run list --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId')" --exit-status
 ```

--- a/project/TODO.md
+++ b/project/TODO.md
@@ -18,9 +18,9 @@
 - [x] **image-scene-descriptions** — pipeline committed; not pushed
 - [x] **Fast-follow** — `tests/test_doc_examples_lint.py` + filled `ALLOWED_STEP_KEYS` gaps
       (`content`, `key`, `where`, `offset`, `columns`) + `prompt_file` doc fixes
-- [ ] **ears-to-hear** — migration on disk; Captain commits with loader-step WIP
-- [ ] **storytelling-dictionary** — migrated on disk; NOT a git repo (cannot commit)
-- [ ] **Propose** `docs/ai-context/json-reliability.md` fix (AI can't edit ai-context)
+- [x] **json-reliability.md** — `response_mime_type`/`response_schema` were real Gemini keys
+      missing from `ALLOWED_STEP_KEYS` (doc was correct); added them + re-included ai-context
+      in the doc-lint scan. No ai-context edit needed.
 - [ ] **Release** — re-cut `v0.2.1.20` with for/in (delete stale tag, re-tag the merge commit)
 
 ### 🔥 Monday priorities

--- a/project/TODO.md
+++ b/project/TODO.md
@@ -7,6 +7,23 @@
 
 ## 🔥 Active
 
+### 🔁 for/in syntax migration (breaking — one syntax, no aliases)
+> See `project/plans/design-foreach-syntax-migration.md`. Systematic commits, one per repo.
+> Migration: `item_var:`→`for:`, `input:`/`over:`→`in:` (for before in). Old keys fail loud.
+- [x] **Core engine** — runtime (for_each/window fail-loud), schema (JSON + pipeline_schema),
+      linter (reject aliases + "did you mean" hints), 25 tests migrated, docs flipped
+- [x] **discourse-flow** — migrated + committed + pushed
+- [ ] **ears-to-hear** — migrate + commit + push
+- [ ] **discourse-flow-hebrew** — migrate + commit + push
+- [ ] **image-scene-descriptions** — migrate + commit
+- [ ] **macula-lxx-greek** — migrate + commit
+- [ ] **semdom-greek-lexicon** — migrate + commit
+- [ ] **storytelling-dictionary** — migrate + commit
+- [ ] **Fast-follow** — commit doc-example lint test (`tests/test_doc_examples_lint.py`) after
+      filling `ALLOWED_STEP_KEYS` gaps it surfaced (`content`, `key`, `where`, `offset`, `columns`)
+      and fixing doc-isms (`prompt_file`); propose `docs/ai-context/json-reliability.md` fix
+- [ ] **Release** — re-cut `v0.2.1.20` with for/in (delete stale tag, re-tag the merge commit)
+
 ### 🔥 Monday priorities
 - [ ] **Fix GUI Content Lifecycle** — Content Lifecycle page displays blank, needs debugging
 - [ ] **Publish v0.2.1.14 to PyPI** — Built and tagged, needs PyPI credentials
@@ -49,6 +66,14 @@
 - [ ] Bootstrap New Project UX improvements → #28
 - [ ] Conditionals and switches → #11
 - [ ] Checkpointing support → #8
+
+### 🗂 Pipeline data operations
+- [ ] Verse range operations (`overlaps`, `contains`, `intersection`, `union`) → #169
+  - Design document: `project/plans/design-verse-range-operations.md`
+  - 6 decisions needed before implementation (see design doc / issue comment)
+- [ ] List transformation: flatten, project, slice as framework primitives → #167
+- [ ] Predicate filtering: filter lists by value / cross-list membership → #168
+- [ ] Accumulator initialization in `variables:` block → #170
 
 ## ✅ Done
 

--- a/project/TODO.md
+++ b/project/TODO.md
@@ -10,18 +10,17 @@
 ### 🔁 for/in syntax migration (breaking — one syntax, no aliases)
 > See `project/plans/design-foreach-syntax-migration.md`. Systematic commits, one per repo.
 > Migration: `item_var:`→`for:`, `input:`/`over:`→`in:` (for before in). Old keys fail loud.
-- [x] **Core engine** — runtime (for_each/window fail-loud), schema (JSON + pipeline_schema),
-      linter (reject aliases + "did you mean" hints), 25 tests migrated, docs flipped
-- [x] **discourse-flow** — migrated + committed + pushed
-- [ ] **ears-to-hear** — migrate + commit + push
-- [ ] **discourse-flow-hebrew** — migrate + commit + push
-- [ ] **image-scene-descriptions** — migrate + commit
-- [ ] **macula-lxx-greek** — migrate + commit
-- [ ] **semdom-greek-lexicon** — migrate + commit
-- [ ] **storytelling-dictionary** — migrate + commit
-- [ ] **Fast-follow** — commit doc-example lint test (`tests/test_doc_examples_lint.py`) after
-      filling `ALLOWED_STEP_KEYS` gaps it surfaced (`content`, `key`, `where`, `offset`, `columns`)
-      and fixing doc-isms (`prompt_file`); propose `docs/ai-context/json-reliability.md` fix
+- [x] **Core engine** — runtime/schema/linter/tests/docs (`86b3f2b`, pushed `dev`)
+- [x] **discourse-flow** — committed + pushed (clean)
+- [x] **discourse-flow-hebrew** — committed + pushed (clean)
+- [x] **semdom-greek-lexicon** — pipeline committed `0e050f6` (incl. in-file WIP); not pushed
+- [x] **macula-lxx-greek** — pipeline committed `b55fca7`; not pushed
+- [x] **image-scene-descriptions** — pipeline committed; not pushed
+- [x] **Fast-follow** — `tests/test_doc_examples_lint.py` + filled `ALLOWED_STEP_KEYS` gaps
+      (`content`, `key`, `where`, `offset`, `columns`) + `prompt_file` doc fixes
+- [ ] **ears-to-hear** — migration on disk; Captain commits with loader-step WIP
+- [ ] **storytelling-dictionary** — migrated on disk; NOT a git repo (cannot commit)
+- [ ] **Propose** `docs/ai-context/json-reliability.md` fix (AI can't edit ai-context)
 - [ ] **Release** — re-cut `v0.2.1.20` with for/in (delete stale tag, re-tag the merge commit)
 
 ### 🔥 Monday priorities

--- a/project/plans/design-foreach-syntax-migration.md
+++ b/project/plans/design-foreach-syntax-migration.md
@@ -1,0 +1,126 @@
+# Design: migrate for-each / window to `for`/`in`, remove aliases
+
+**Date:** 2026-07-11
+**Status:** Proposed — awaiting Captain review
+**Decision:** Option 3 — converge on the XQuery-style `for`/`in` as the **only** loop syntax;
+remove `item_var`/`input`/`over`/`as` entirely (no aliases).
+**Breaking:** yes. Coordinated across this repo + 7 registered consumer repos.
+
+## Motivation
+
+The JSON Schema (`pipeline.schema.json`, added in `f34aa1b`) declares `for`/`in` as the
+loop-step fields and marks `item_var`/`input`/`over`/`as` as *"Deprecated: use for/in."* But
+**no runtime code reads `for`/`in`** — `for_each.py`/`window.py`/`linter.py` read only
+`item_var`/`input`/`over`. So the schema (and the VS Code autocomplete it powers) instructs
+users to write `for:`/`in:`, which the runtime **silently ignores**: `input` defaults to `[]`,
+`item_var` to `"item"`/`"window"`, and the loop iterates over nothing. A silent-failure trap.
+
+Rather than keep two spellings, we make `for`/`in` real and drop the rest. One syntax, schema
+and runtime finally agree. Doing it now is cheap: all pipelines are the Captain's, all on one
+machine, all in the registry — a bounded, known set. The cost only grows with users.
+
+## Canonical syntax (after)
+
+```yaml
+- type: for-each
+  in: "${list}"        # was: input
+  for: item            # was: item_var
+  order-by: ...        # unchanged
+  group-by: ...        # unchanged
+  parallel: N          # unchanged
+  steps: [...]
+
+- type: window
+  in: "${list}"        # was: input (or over)
+  for: chunk           # was: item_var
+  size / stride / ...  # unchanged
+  steps: [...]
+```
+
+## Blast radius (measured via the registry)
+
+**Consumer repos — 7 projects, ~25 sites:**
+
+| Project | for-each | window |
+|---|---:|---:|
+| ears-to-hear | 11 | 0 |
+| discourse-flow | 4 | 1 |
+| image-scene-descriptions | 3 | 0 |
+| discourse-flow-hebrew | 2 | 1 |
+| macula-lxx-greek | 1 | 0 |
+| semdom-greek-lexicon | 1 | 0 |
+| storytelling-dictionary | 1 | 0 |
+
+**This repo (core):**
+- Runtime: `for_each.py:266,268`; `window.py:305,312`
+- Linter: `linter.py:568` (reads `item_var`), known-keys list `89–102`, `_build_available_context` `527–542`
+- Schema: for-each props `254–272` (drop `item_var`,`input`,`as`); window props `323–349` (drop `item_var`,`input`,`over`,`as`); keep/make required `for`,`in`
+- Example pipelines: 8 files using `item_var:`
+- Tests: 25 files / ~148 lines referencing `item_var`
+- Docs: `docs/llmflow-language.md` (for-each example + the currently-uncommitted `window` section), `docs/llmflow-language-quickref.md`
+
+## Design decisions
+
+1. **Fail loud, not silent.** After aliases are removed, a loop step whose loop var / list
+   cannot be resolved must **raise a clear error**, not default to empty iteration. Both:
+   - Runtime: `for_each`/`window` raise if `for`/`in` are absent (no silent `[]`/`"item"`).
+   - Linter: `item_var`/`input`/`over`/`as` become **unknown keys** → `sp lint` flags any
+     un-migrated pipeline. This is the safety net that makes the migration detectable.
+2. **Internal names unchanged.** The Python locals may stay named `item_var` etc.; only the
+   *step key* that is read changes (`step.get("item_var")` → `step.get("for")`).
+3. **`in`/`inputs` never confused.** The loop list key is singular `input:` → `in:`. Prompt
+   `inputs:` (plural) is unrelated and must never be touched.
+
+## Work breakdown
+
+### Phase 1 — Core engine (this repo), TDD
+1. Update `for_each.py`, `window.py` to read `for`/`in`; remove `item_var`/`input`/`over`
+   fallbacks; raise on absence.
+2. Update `linter.py`: known-keys list (`for`/`in` in, aliases out), `item_var` read site,
+   `_build_available_context`.
+3. Update `pipeline.schema.json`: remove deprecated alias properties; require `for`/`in`.
+4. Migrate the 8 example pipelines + 25 test files (write/adjust tests first per TDD).
+5. Update `docs/llmflow-language.md` (+ quickref) to `for`/`in`; commit the held language-doc
+   edits reworded accordingly.
+6. Full suite green; `sp lint` clean on example pipelines.
+
+### Phase 2 — Codemod
+A block-aware transformer (ruamel.yaml to preserve comments/formatting), applied per repo:
+- Walk every step; for `type in {for-each, window}`: rename `item_var`→`for`, `input`→`in`,
+  `over`→`in`; drop `as`.
+- Leave all other keys (including prompt `inputs:`) untouched.
+- After transform: run `sp lint` on every pipeline; must be clean (unknown-key check confirms
+  no alias survived).
+Ship the codemod in-repo (e.g. `scripts/migrate_foreach_syntax.py`) so consumers can run it.
+
+### Phase 3 — Consumer repos (7)
+Per repo, in lockstep with however it consumes the engine (vendored `LLMFlow/` subdir vs
+`pip install scripture-pipelines`):
+- Bump/point to the alias-free engine version.
+- Run the codemod on its pipelines.
+- `sp lint` all pipelines clean.
+- Own branch + commit/PR per repo (start with ears-to-hear — 11 sites, the largest).
+
+## Sequencing & versioning
+
+- **After 0.2.1.20** (already released). This is the next unit of work.
+- **Version: 0.2.1.21 (4th-component bump).** Breaking, but the Captain's call (2026-07-11):
+  with no significant user base yet, the small bump is acceptable and keeps numbering
+  consistent. The CHANGELOG entry must still clearly mark it **breaking** (the syntax change).
+  (Relates to #153 versioning policy, which can revisit this once there are users.)
+- Order: Phase 1 lands + releases the new engine; then Phase 3 migrates each consumer against
+  it. A consumer must not pick up the alias-free engine before its pipelines are migrated —
+  but the fail-loud linter/runtime guarantees any miss is caught immediately, not silent.
+
+## Risks
+
+- **R1 — a consumer updates the engine before migrating.** Mitigated by fail-loud (Design 1):
+  the step errors / lint fails rather than iterating empty.
+- **R2 — codemod reformats YAML.** Mitigated by ruamel.yaml round-trip (preserves comments);
+  review the diff per repo.
+- **R3 — `input:` used as a non-loop key somewhere.** The codemod only renames within
+  `for-each`/`window` steps, so other `input:`/`inputs:` are safe.
+
+## Out of scope
+- Other schema deprecations (e.g. `input`→`inputs` at schema:810) — separate concern.
+- The consumer-coupling audit findings (`project/audits/2026-07-09_consumer-coupling_*`).

--- a/project/plans/design-pr-build-promote.md
+++ b/project/plans/design-pr-build-promote.md
@@ -1,0 +1,173 @@
+# Design: Build-on-PR, Bless-on-Merge, Promote-on-Tag
+
+**Status:** Proposed — awaiting Captain review
+**Author:** AI (at Captain's direction)
+**Date:** 2026-07-07
+**Related:** PR #173 (Release 0.2.1.20), `.github/workflows/build-release.yml`, `.github/workflows/test.yml`
+
+## Problem
+
+The 3-platform Nuitka build (`build-release.yml`) only fires on a `v*` **tag** — i.e.
+*after* merge to `main`. Consequences:
+
+1. **Broken builds are discovered too late.** v0.2.1.19's build failed at tag time,
+   with the code already merged. ("Why merge code that fails to build?")
+2. **The expensive build runs at the worst moment** — post-merge, when it's hardest to
+   back out.
+3. **No pre-merge signal.** PRs only run `test.yml` (Linux-only pytest), never a build.
+
+## Goal
+
+- Build the Linux/macOS/Windows binaries **on the PR**, and make that build a
+  **required check** so a failing build blocks merge.
+- **Reuse those exact binaries** as the release assets on tag — build once, not twice.
+- Keep the release step **deliberate** (explicit `v*` tag push).
+
+## Decisions (confirmed with Captain, 2026-07-07)
+
+| Decision | Choice |
+|----------|--------|
+| Blessing mechanism | **PR approval + merge.** Green required build + merge = blessed. No Environment gate. |
+| Publish trigger | **Push a `v*` tag.** Merge to main does not auto-release. |
+| Ship *.20 | **Dogfood the new flow** on PR #173. |
+
+## Non-goals
+
+- Auto-releasing on merge to `main`.
+- Byte-reproducible builds (see Risk R1 — we *reuse* the artifact precisely because
+  Nuitka output is not reproducible).
+- Changing what the binaries contain or how Nuitka is invoked.
+
+## Architecture
+
+Split the monolithic `build-release.yml` into two workflows.
+
+### `build.yml` — the merge gate (build once)
+
+```
+on:
+  pull_request:            # the gate
+  workflow_dispatch:       # manual smoke build on any branch
+  # (optionally) push: branches: [dev]  -- see Open Question Q1
+```
+
+Jobs (largely lifted from today's `test` + `build` jobs):
+
+- **test** — frontend tests, tsc, GUI build, Pyright, backend pytest (with empty API-key
+  env, as today).
+- **build** (matrix: ubuntu / macos / windows) — install deps, build GUI, Nuitka build,
+  **smoke-test the binary** (`--version`, `lint`, `run --dry-run`), then
+  **`actions/upload-artifact`** each binary (**retention 7 days** — see Q2). No release
+  upload here.
+
+**Required-check wiring:** add `build.yml`'s jobs to branch protection on `main` as
+required status checks (Captain / repo-admin action — see Rollout step 5).
+
+### `release.yml` — promote the blessed artifacts (no rebuild)
+
+```
+on:
+  push:
+    tags: ['v*']
+```
+
+Jobs:
+
+1. **resolve-build** — determine the commit whose artifacts to promote, find the
+   successful `build.yml` run for it, expose its `run_id`. (See "Artifact correlation".)
+2. **create-release** — `gh release create --draft --generate-notes`.
+3. **promote** — `gh run download <run_id>` to fetch the three binaries, then
+   `gh release upload` them to the draft. **No Nuitka build.**
+4. **publish-release** — flip draft → published.
+5. **verify-install** (matrix 3 OS) — unchanged from today.
+6. **publish-pypi** — unchanged from today (`hatch build` + PyPI publish; this one *does*
+   rebuild the wheel, which is cheap and correct).
+
+## Artifact correlation (the crux)
+
+To promote the PR-built binary at tag time we must map the tag back to the build run.
+
+**The `pull_request` gotcha:** for `pull_request` events, `github.sha` is an ephemeral
+merge-preview commit. But the **workflow run's `head_sha` is the PR head commit**, so
+`gh run list -w build.yml -c <pr-head-sha> -s success` locates the run.
+
+**Making the mapping deterministic — two constraints:**
+
+1. **Require PR branches be up-to-date with `main` before merge** (branch protection).
+   Then the merge-preview tree the build ran against == the tree that lands on `main`.
+2. **Use merge commits** (not squash/rebase) when merging to `main`. Then on the tagged
+   commit, `git rev-parse HEAD^2` == the PR head SHA that was built.
+
+**resolve-build logic:**
+```
+candidates = [HEAD^2 (if merge commit), HEAD]      # cover merge-commit and FF cases
+for sha in candidates:
+    run_id = gh run list -w build.yml -c <sha> -s success --limit 1 --json databaseId
+    if run_id: break
+fail loudly if none found (do NOT silently rebuild — surface it)
+```
+
+**To also reflect the exact PR head in the binary** (belt-and-suspenders): in `build.yml`,
+for `pull_request` events check out `${{ github.event.pull_request.head.sha }}` rather
+than the merge ref, so the artifact is built from the head commit that will become
+`HEAD^2`.
+
+## Risks
+
+- **R1 — Nuitka not byte-reproducible.** Mitigated by *reusing* the artifact rather than
+  rebuilding. This is strictly safer than today's rebuild-at-tag.
+- **R2 — Artifact retention window.** Set to **7 days** (Captain: a PR not merged within a
+  week is stale). A tag pushed after that finds artifacts expired; `resolve-build` fails
+  loudly (never silently rebuilds), so this is visible, not silent — and correctly forces
+  a fresh build for a stale branch.
+- **R3 — `gh run list -c` matching PR runs by head_sha.** High confidence, but validate
+  during implementation (Rollout step 3).
+- **R4 — Fork PRs** can't write artifacts with the needed token scope. Not a concern:
+  this is a single-maintainer repo; PRs come from branches, not forks.
+
+## Prerequisite (separate scope): fix the 2 failing tests
+
+`test.yml` is currently red on `dev` — this blocks *.20 regardless of CI redesign:
+
+1. `test_cost_fallback_gpt5.py::test_gpt5_cost_estimation_when_usage_missing` — makes a
+   real `gpt-5` call, dies on missing `OPENAI_API_KEY`. Needs mock or key-gated skip.
+2. `test_prompt_path_resolution.py::test_cli_run_reports_prompt_error_not_pipeline_error`
+   — `SystemExit: 1` on missing prompt; expectation mismatch.
+
+Each gets its own TDD fix under the authorization workflow. **Not** part of this CI design.
+
+## Rollout (dogfooding *.20 on PR #173)
+
+1. Fix the 2 failing tests on `dev` (separate authorization).
+2. Add `build.yml` + `release.yml`; retire `build-release.yml`. Because `pull_request`
+   runs use the workflow from the PR branch, PR #173 immediately gets a real 3-platform
+   build.
+3. Validate on the PR: build matrix green, artifacts uploaded; confirm R3 (`gh run list -c`
+   finds the run by PR head sha).
+4. Confirm both required checks (test + build) are green on PR #173.
+5. **Captain / repo-admin:** set branch protection on `main` — require `test` and `build`
+   checks, require branches up-to-date. Confirm merge method = merge commit.
+6. Merge PR #173 to `main` (the blessing).
+7. Tag `v0.2.1.20` → `release.yml` resolves the build run, downloads + promotes the
+   blessed binaries, publishes, verifies install, publishes to PyPI.
+8. Update `RELEASE_CHECKLIST.md` to reflect promote-not-rebuild.
+
+## Resolved decisions (Captain, 2026-07-07)
+
+- **Q1 — PR-only.** Build on `pull_request` + `workflow_dispatch`. No push-to-`dev`
+  trigger.
+- **Q2 — Retention 7 days.** A PR not merged within ~a week is stale; a stale branch
+  *should* be forced to rebuild rather than promote old binaries.
+- **Q3 — Keep `verify-install` sequential** after `publish-release`, as today.
+- **Branch protection — deferred.** The Captain will configure the required checks +
+  up-to-date + merge-commit settings later; not a blocker for landing the workflows.
+  See caveat below.
+
+### Caveat: workflows land before branch protection
+
+Until the Captain enables branch protection, the `build` check runs on PRs but does **not
+mechanically block** merge, and the "up-to-date + merge commit" constraints aren't
+enforced. For the *.20 dogfood this is fine — we follow them **manually**: confirm the PR
+build is green before merging, ensure #173 is up-to-date with `main`, and merge with a
+merge commit. The promotion machinery works regardless; branch protection just makes the
+discipline automatic later.

--- a/src/llmflow/cli_utils.py
+++ b/src/llmflow/cli_utils.py
@@ -320,11 +320,11 @@ Loops over a list variable and runs nested steps for each item.
 ```yaml
 - name: process_each_item
   type: for-each
-  input: "${items}"
-  item_var: item
+  for: item
+  in: "${items}"
   parallel: 4                      # optional: run up to 4 iterations concurrently
-  group_by: "${item.category}"     # optional: group results by this field
-  order_by: "${item.sequence}"     # optional: sort results within groups
+  group-by: "${item.category}"     # optional: group results by this field
+  order-by: "${item.sequence}"     # optional: sort results within groups
   steps:
     - name: handle-item
       type: llm
@@ -336,14 +336,14 @@ Loops over a list variable and runs nested steps for each item.
       append_to: all_results
 ```
 
-- `input` points to a list value.
-- `item_var` is the name used to refer to each element.
+- `for` is the name used to refer to each element (XQuery-style: `for $x in $list`).
+- `in` points to the list value.
 - Use `append_to` in nested steps to build a list across iterations.
 - `parallel: N` runs N iterations concurrently; results are collected in
   input order regardless. Omit for sequential execution (default).
-- `group_by` and `order_by` accept `${expr}` expressions evaluated against
-  each item. `group_by` groups `append_to` results by the expression value;
-  `order_by` sorts within each group.
+- `group-by` and `order-by` accept `${expr}` expressions evaluated against
+  each item. `group-by` groups `append_to` results by the expression value;
+  `order-by` sorts within each group.
 
 ### type: `window`
 
@@ -353,8 +353,8 @@ steps on each slice. Useful when a list is too large to process at once.
 ```yaml
 - name: segment_by_windows
   type: window
-  input: "${content_list}"
-  item_var: window_content
+  for: window_content
+  in: "${content_list}"
   size: 50                   # fixed: 50 items per window
   # or: size_by_tokens: 4000 # token-aware: ~4000 tokens per window
   include_partial: true      # include the last partial window
@@ -406,8 +406,8 @@ appended by earlier iterations. This enables "rolling context" patterns:
 ```yaml
 - name: analyze_pericopes
   type: for-each
-  input: "${leaf_pericopes}"
-  item_var: pericope
+  for: pericope
+  in: "${leaf_pericopes}"
   steps:
     - name: analyze
       type: llm

--- a/src/llmflow/pipeline_schema.py
+++ b/src/llmflow/pipeline_schema.py
@@ -46,10 +46,8 @@ class StepConfig(BaseModel):
     type: Optional[str] = None
     function: Optional[str] = None
     inputs: Optional[dict] = None
-    input: Optional[str] = None  # For for-each steps
     outputs: Optional[Union[str, List[str]]] = None
     prompt: Optional[dict] = None
-    item_var: Optional[str] = None
     steps: Optional[List["StepConfig"]] = None
     append_to: Optional[str] = None
     log: Optional[str] = None
@@ -117,7 +115,7 @@ PIPELINE_SCHEMA = {
                     "max_tokens": {"type": "integer"},
                     "temperature": {"type": "number"},
                     "timeout_seconds": {"type": "number"},
-                    "input": {},
+                    "in": {},
                     "inputs": {"type": "object"},
                     "outputs": {
                         "oneOf": [
@@ -127,7 +125,7 @@ PIPELINE_SCHEMA = {
                     },
                     "append_to": {"type": "string"},
                     "steps": {"type": "array"},
-                    "item_var": {"type": "string"},
+                    "for": {"type": "string"},
                     "condition": {"type": "string"},
                     "saveas": {
                         "oneOf": [

--- a/src/llmflow/schema/pipeline.schema.json
+++ b/src/llmflow/schema/pipeline.schema.json
@@ -259,21 +259,6 @@
               "type": "string",
               "description": "Context variable resolving to the list to iterate over. Follows XQuery: for $scene in $list."
             },
-            "item_var": {
-              "type": "string",
-              "description": "Deprecated: use for.",
-              "deprecated": true
-            },
-            "input": {
-              "type": "string",
-              "description": "Deprecated: use in.",
-              "deprecated": true
-            },
-            "as": {
-              "type": "string",
-              "description": "Deprecated: use for.",
-              "deprecated": true
-            },
             "steps": {
               "type": "array",
               "minItems": 1,
@@ -298,7 +283,7 @@
               "description": "Template for per-iteration log labels. Supports ${var} substitution."
             }
           },
-          "required": ["type", "steps"]
+          "required": ["type", "for", "in", "steps"]
         }
       ]
     },
@@ -328,26 +313,6 @@
             "in": {
               "type": "string",
               "description": "Context variable resolving to the list to window over. Follows XQuery: for $w in $list."
-            },
-            "item_var": {
-              "type": "string",
-              "description": "Deprecated: use for.",
-              "deprecated": true
-            },
-            "input": {
-              "type": "string",
-              "description": "Deprecated: use in.",
-              "deprecated": true
-            },
-            "over": {
-              "type": "string",
-              "description": "Deprecated: use in.",
-              "deprecated": true
-            },
-            "as": {
-              "type": "string",
-              "description": "Deprecated: use for.",
-              "deprecated": true
             },
             "size": {
               "type": "integer",
@@ -391,7 +356,7 @@
               "description": "Steps to execute for each window."
             }
           },
-          "required": ["type", "steps"]
+          "required": ["type", "for", "in", "steps"]
         }
       ]
     },

--- a/src/llmflow/steps/for_each.py
+++ b/src/llmflow/steps/for_each.py
@@ -263,12 +263,22 @@ def run_for_each_step(
     if run_step_fn is None:
         from llmflow.runner import run_step
         run_step_fn = run_step
-    _input_raw = resolve(step.get("input", []), context)
+    step_name = step.get("name", "unnamed")
+    if "in" not in step:
+        raise ValueError(
+            f"for-each step '{step_name}': missing required 'in' key (the list to iterate "
+            f"over). The legacy 'input' key was removed — use 'in'."
+        )
+    if "for" not in step:
+        raise ValueError(
+            f"for-each step '{step_name}': missing required 'for' key (the loop variable "
+            f"name). The legacy 'item_var' key was removed — use 'for'."
+        )
+    _input_raw = resolve(step.get("in"), context)
     input_data: list = _input_raw if isinstance(_input_raw, list) else list(_input_raw)
-    item_var = step.get("item_var", "item")
+    item_var: str = str(step["for"])
     steps = step.get("steps", [])
     debug_label_template = step.get("debug_label")
-    step_name = step.get("name", "unnamed")
     parallel = step.get("parallel", 1)
     group_by_expr = step.get("group-by")
     order_by = step.get("order-by")

--- a/src/llmflow/steps/window.py
+++ b/src/llmflow/steps/window.py
@@ -302,14 +302,24 @@ def run_window_step(
     from llmflow.steps.function import run_function_step
 
     step_name = step.get("name", "unnamed")
-    input_data = resolve(step.get("input", step.get("over", [])), context)
+    if "in" not in step:
+        raise ValueError(
+            f"Window step '{step_name}': missing required 'in' key (the list to window "
+            f"over). The legacy 'input'/'over' keys were removed — use 'in'."
+        )
+    if "for" not in step:
+        raise ValueError(
+            f"Window step '{step_name}': missing required 'for' key (the window variable "
+            f"name). The legacy 'item_var' key was removed — use 'for'."
+        )
+    input_data = resolve(step.get("in"), context)
     if not isinstance(input_data, list):
         raise ValueError(
-            f"Window step '{step_name}': input must resolve to a list, "
+            f"Window step '{step_name}': 'in' must resolve to a list, "
             f"got {type(input_data).__name__}"
         )
 
-    item_var = step.get("item_var", "window")
+    item_var: str = str(step["for"])
     steps = step.get("steps", [])
     size = step.get("size")
     stride = step.get("stride", size)

--- a/src/llmflow/utils/linter.py
+++ b/src/llmflow/utils/linter.py
@@ -80,6 +80,12 @@ _EXTRA_STEP_KEYS = {
     # loader step keys
     "pattern",
     "delimiter",
+    "key",        # load_json/load_yaml: sub-document extraction
+    "where",      # load_csv/load_tsv: row filter
+    "offset",     # load_csv/load_tsv: skip N rows
+    "columns",    # load_csv/load_tsv: column projection
+    # save step keys
+    "content",
     # basex step keys
     "database",
     "query",

--- a/src/llmflow/utils/linter.py
+++ b/src/llmflow/utils/linter.py
@@ -61,6 +61,8 @@ _EXTRA_STEP_KEYS = {
     "output_type",
     "plugin",
     "response_format",
+    "response_mime_type",  # Gemini native JSON MIME type
+    "response_schema",     # Gemini native JSON schema
     "temperature",
     "timeout_seconds",
     "mcp",

--- a/src/llmflow/utils/linter.py
+++ b/src/llmflow/utils/linter.py
@@ -86,7 +86,9 @@ _EXTRA_STEP_KEYS = {
     "query_file",
     "params",
     "timeout",
-    # for-each keys
+    # for-each / window loop keys (XQuery-style)
+    "for",
+    "in",
     "parallel",
     "group-by",
     "order-by",
@@ -99,8 +101,6 @@ _EXTRA_STEP_KEYS = {
     "size_by_tokens",
     "stride_by_tokens",
     "merge",
-    "item_var",
-    "over",
 }
 
 ALLOWED_STEP_KEYS = _SCHEMA_STEP_KEYS | _EXTRA_STEP_KEYS
@@ -111,6 +111,13 @@ COMMON_TYPOS = {
     "intputs": "inputs",
     "inputss": "inputs",
     "apend_to": "append_to",
+    # Removed loop-key aliases (migrated to XQuery-style for/in) — guide the fix.
+    "item_var": "for",
+    "input": "in",
+    "over": "in",
+    # Wrong-format modifier keys (schema uses hyphens, not underscores).
+    "group_by": "group-by",
+    "order_by": "order-by",
 }
 
 from llmflow.modules.logger import Logger
@@ -565,8 +572,8 @@ def _validate_variable_references_recursive(steps, pipeline_vars, parent_outputs
         step_type = step.get("type", "")
 
         # Build available context for this step
-        item_var = step.get("item_var")
-        for_each_input = step.get("input")  # for-each uses "input" not "for-each"
+        item_var = step.get("for")  # for-each/window loop variable
+        for_each_input = step.get("in")  # the list expression
 
         # Combine parent item_vars with current item_var
         current_item_vars = parent_item_vars.copy()

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -98,8 +98,8 @@ variables:
 steps:
   - name: process-items
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: nested-step
         type: llm
@@ -133,8 +133,8 @@ variables:
 steps:
   - name: process-items
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: nested-step1
         type: llm
@@ -310,13 +310,13 @@ variables:
 steps:
   - name: outer-loop
     type: for-each
-    input: "${outer_items}"
-    item_var: outer
+    in: "${outer_items}"
+    for: outer
     steps:
       - name: inner-loop
         type: for-each
-        input: "${inner_items}"
-        item_var: inner
+        in: "${inner_items}"
+        for: inner
         steps:
           - name: nested-step
             type: llm
@@ -348,8 +348,8 @@ variables:
 steps:
   - name: process-items
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: nested-step
         type: llm
@@ -444,8 +444,8 @@ steps:
       - result1
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: nested-step
         type: llm
@@ -583,8 +583,8 @@ steps:
       - result1
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: nested
         type: llm
@@ -677,8 +677,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: step1
         type: llm
@@ -749,8 +749,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${{items}}"
-    item_var: item
+    in: "${{items}}"
+    for: item
     steps:
       - name: save1
         type: save
@@ -789,8 +789,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${{items}}"
-    item_var: item
+    in: "${{items}}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -831,8 +831,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -866,8 +866,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: skip-step
         type: llm
@@ -950,8 +950,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -991,8 +991,8 @@ variables:
 steps:
   - name: loop1
     type: for-each
-    input: "${items1}"
-    item_var: item
+    in: "${items1}"
+    for: item
     steps:
       - name: step1
         type: llm
@@ -1012,8 +1012,8 @@ steps:
           - r2
   - name: loop2
     type: for-each
-    input: "${items2}"
-    item_var: item
+    in: "${items2}"
+    for: item
     steps:
       - name: step3
         type: llm
@@ -1154,8 +1154,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: step1
         type: llm
@@ -1197,8 +1197,8 @@ variables:
 steps:
   - name: search
     type: for-each
-    input: "${candidates}"
-    item_var: candidate
+    in: "${candidates}"
+    for: candidate
     steps:
       - name: check
         type: if
@@ -1292,8 +1292,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -1336,18 +1336,18 @@ variables:
 steps:
   - name: outer
     type: for-each
-    input: "${level1}"
-    item_var: l1
+    in: "${level1}"
+    for: l1
     steps:
       - name: middle
         type: for-each
-        input: "${level2}"
-        item_var: l2
+        in: "${level2}"
+        for: l2
         steps:
           - name: inner
             type: for-each
-            input: "${level3}"
-            item_var: l3
+            in: "${level3}"
+            for: l3
             steps:
               - name: deepest
                 type: llm

--- a/tests/test_critical_foreach_context.py
+++ b/tests/test_critical_foreach_context.py
@@ -12,8 +12,8 @@ class TestCriticalForEachContext:
         rule = {
             "name": "test_isolation",
             "type": "for-each",
-            "input": "${items}",
-            "item_var": "item",
+            "in": "${items}",
+            "for": "item",
             "steps": [
                 {
                     "name": "mutate_context",
@@ -44,8 +44,8 @@ class TestCriticalForEachContext:
         rule = {
             "name": "test_deepcopy",
             "type": "for-each",
-            "input": ["item1", "item2", "item3"],
-            "item_var": "item",
+            "in": ["item1", "item2", "item3"],
+            "for": "item",
             "steps": [
                 {
                     "name": "append_to_list",
@@ -73,8 +73,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -105,13 +105,13 @@ variables:
 steps:
   - name: outer-loop
     type: for-each
-    input: "${outer}"
-    item_var: o
+    in: "${outer}"
+    for: o
     steps:
       - name: inner-loop
         type: for-each
-        input: "${inner}"
-        item_var: i
+        in: "${inner}"
+        for: i
         steps:
           - name: process
             type: llm
@@ -144,8 +144,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -187,8 +187,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: mutate-attempt
         type: function
@@ -222,8 +222,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -256,8 +256,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -297,8 +297,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -331,8 +331,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -361,8 +361,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -397,8 +397,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: check
         type: if
@@ -439,8 +439,8 @@ variables:
 steps:
   - name: loop1
     type: for-each
-    input: "${items1}"
-    item_var: item
+    in: "${items1}"
+    for: item
     steps:
       - name: process1
         type: llm
@@ -452,8 +452,8 @@ steps:
         append_to: results1
   - name: loop2
     type: for-each
-    input: "${items2}"
-    item_var: item
+    in: "${items2}"
+    for: item
     steps:
       - name: process2
         type: llm
@@ -491,8 +491,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${{items}}"
-    item_var: item
+    in: "${{items}}"
+    for: item
     steps:
       - name: save
         type: save
@@ -521,8 +521,8 @@ variables:
 steps:
   - name: loop1
     type: for-each
-    input: "${items1}"
-    item_var: letter
+    in: "${items1}"
+    for: letter
     steps:
       - name: process1
         type: llm
@@ -534,8 +534,8 @@ steps:
         append_to: list1
   - name: loop2
     type: for-each
-    input: "${items2}"
-    item_var: number
+    in: "${items2}"
+    for: number
     steps:
       - name: process2
         type: llm
@@ -568,8 +568,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm
@@ -606,18 +606,18 @@ variables:
 steps:
   - name: outer
     type: for-each
-    input: "${level1}"
-    item_var: l1
+    in: "${level1}"
+    for: l1
     steps:
       - name: middle
         type: for-each
-        input: "${level2}"
-        item_var: l2
+        in: "${level2}"
+        for: l2
         steps:
           - name: inner
             type: for-each
-            input: "${level3}"
-            item_var: l3
+            in: "${level3}"
+            for: l3
             steps:
               - name: deepest
                 type: llm
@@ -657,8 +657,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: process
         type: llm

--- a/tests/test_critical_foreach_context_fix.py
+++ b/tests/test_critical_foreach_context_fix.py
@@ -20,8 +20,8 @@ class TestCriticalForEachContext:
         rule = {
             "name": "test_deepcopy",
             "type": "for-each",
-            "input": ["item1", "item2", "item3"],
-            "item_var": "item",
+            "in": ["item1", "item2", "item3"],
+            "for": "item",
             "steps": [
                 {
                     "name": "append_to_list",
@@ -52,8 +52,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: "${items}"
-    item_var: item
+    in: "${items}"
+    for: item
     steps:
       - name: mutate-attempt
         type: function

--- a/tests/test_critical_pipeline_flow.py
+++ b/tests/test_critical_pipeline_flow.py
@@ -28,8 +28,8 @@ class TestCriticalPipelineFlow:
                     {
                         "name": "process_scenes",
                         "type": "for-each",
-                        "input": "${scenes}",
-                        "item_var": "scene",
+                        "in": "${scenes}",
+                        "for": "scene",
                         "steps": [
                             {
                                 "name": "generate_content",

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -155,8 +155,8 @@ class TestDebugLogging:
                 {
                     "name": "for_each_with_debug",
                     "type": "for-each",
-                    "input": "${passages}",
-                    "item_var": "passage",
+                    "in": "${passages}",
+                    "for": "passage",
                     "steps": [
                         {
                             "name": "parse_in_loop",

--- a/tests/test_doc_examples_lint.py
+++ b/tests/test_doc_examples_lint.py
@@ -32,10 +32,7 @@ _FENCE_RE = re.compile(r"```ya?ml\n(.*?)```", re.DOTALL)
 
 
 def _iter_yaml_blocks():
-    # docs/ai-context/ is the Captain's domain (AI must not edit it), so it is not
-    # validated here — its examples are curated separately.
-    sources = [p for p in (REPO_ROOT / "docs").rglob("*.md")
-               if "ai-context" not in p.parts]
+    sources = list((REPO_ROOT / "docs").rglob("*.md"))
     sources.append(REPO_ROOT / "src" / "llmflow" / "cli_utils.py")
     for path in sources:
         text = path.read_text(encoding="utf-8")

--- a/tests/test_doc_examples_lint.py
+++ b/tests/test_doc_examples_lint.py
@@ -1,0 +1,86 @@
+"""Guardrail: YAML examples in documentation must use real step keywords.
+
+This catches the class of bug where a doc example uses a key that the runtime
+silently ignores — e.g. `group_by:` (should be `group-by:`) or a removed alias
+like `item_var:`/`input:` (should be `for:`/`in:`). Such examples teach users
+to write pipelines that fail silently, and they are never otherwise linted.
+
+Validation is intentionally *key-level only* (not full-pipeline structure) so
+that partial snippets — a lone step with no `name`/`steps` — do not
+false-positive. A block can opt out with a `# lint-doc: skip` marker.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from llmflow.utils.linter import ALLOWED_STEP_KEYS, COMMON_TYPOS
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Dicts whose `type` is one of these are treated as pipeline steps and key-checked.
+KNOWN_STEP_TYPES = {
+    "llm", "function", "for-each", "window", "if", "json", "save",
+    "basex", "duckdb", "plugin", "xpath", "xslt", "tsv",
+    "load_json", "load_yaml", "load_xml", "load_csv", "load_tsv",
+    "load_text", "load_directory",
+}
+
+# Files whose ```yaml fenced blocks we validate: all docs, plus the embedded
+# help/tutorial YAML in cli_utils.py (where doc examples also live).
+_FENCE_RE = re.compile(r"```ya?ml\n(.*?)```", re.DOTALL)
+
+
+def _iter_yaml_blocks():
+    # docs/ai-context/ is the Captain's domain (AI must not edit it), so it is not
+    # validated here — its examples are curated separately.
+    sources = [p for p in (REPO_ROOT / "docs").rglob("*.md")
+               if "ai-context" not in p.parts]
+    sources.append(REPO_ROOT / "src" / "llmflow" / "cli_utils.py")
+    for path in sources:
+        text = path.read_text(encoding="utf-8")
+        for block in _FENCE_RE.findall(text):
+            if "lint-doc: skip" in block:
+                continue
+            yield path, block
+
+
+def _walk_steps(node):
+    """Yield every dict that looks like a pipeline step (type in KNOWN_STEP_TYPES)."""
+    if isinstance(node, dict):
+        if node.get("type") in KNOWN_STEP_TYPES:
+            yield node
+        for v in node.values():
+            yield from _walk_steps(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from _walk_steps(v)
+
+
+def test_doc_yaml_examples_use_known_step_keys():
+    import yaml
+
+    violations = []
+    for path, block in _iter_yaml_blocks():
+        try:
+            parsed = yaml.safe_load(block)
+        except yaml.YAMLError:
+            # Illustrative / non-parseable snippet (e.g. contains {{templates}}); skip.
+            continue
+        for step in _walk_steps(parsed):
+            name = step.get("name", "<unnamed>")
+            for key in step:
+                if key not in ALLOWED_STEP_KEYS:
+                    hint = COMMON_TYPOS.get(key)
+                    rel = path.relative_to(REPO_ROOT)
+                    msg = f"{rel}: step '{name}' (type: {step.get('type')}) uses unknown key '{key}'"
+                    if hint:
+                        msg += f" — did you mean '{hint}'?"
+                    violations.append(msg)
+
+    assert not violations, (
+        "Documentation YAML examples use step keys the runtime does not "
+        "recognise (they would be silently ignored). Fix the example, or add a "
+        "'# lint-doc: skip' comment if the block is intentionally invalid:\n\n"
+        + "\n".join(f"  - {v}" for v in violations)
+    )

--- a/tests/test_for_each_append_bug.py
+++ b/tests/test_for_each_append_bug.py
@@ -22,8 +22,8 @@ class TestForEachAppendBug:
         rule = {
             "name": "test",
             "type": "for-each",
-            "input": "${items}",
-            "item_var": "item",
+            "in": "${items}",
+            "for": "item",
             "steps": [
                 {
                     "name": "process",
@@ -61,8 +61,8 @@ class TestForEachAppendBug:
         rule = {
             "name": "test",
             "type": "for-each",
-            "input": "${items}",
-            "item_var": "item",
+            "in": "${items}",
+            "for": "item",
             "steps": [
                 {
                     "name": "process",
@@ -106,8 +106,8 @@ class TestForEachAppendBug:
         rule = {
             "name": "test",
             "type": "for-each",
-            "input": "${items}",
-            "item_var": "item",
+            "in": "${items}",
+            "for": "item",
             "steps": [
                 {
                     "name": "process",
@@ -136,14 +136,14 @@ class TestForEachAppendBug:
         rule = {
             "name": "outer_loop",
             "type": "for-each",
-            "input": "${outer}",
-            "item_var": "outer_item",
+            "in": "${outer}",
+            "for": "outer_item",
             "steps": [
                 {
                     "name": "inner_loop",
                     "type": "for-each",
-                    "input": "${inner}",
-                    "item_var": "inner_item",
+                    "in": "${inner}",
+                    "for": "inner_item",
                     "steps": [
                         {
                             "name": "combine",

--- a/tests/test_for_each_minimal_bug.py
+++ b/tests/test_for_each_minimal_bug.py
@@ -24,8 +24,8 @@ def test_minimal_for_each_append_bug():
         rule = {
             "name": "test",
             "type": "for-each",
-            "input": "${items}",
-            "item_var": "item",
+            "in": "${items}",
+            "for": "item",
             "steps": [
                 {
                     "name": "process",

--- a/tests/test_foreach_output_propagation.py
+++ b/tests/test_foreach_output_propagation.py
@@ -16,8 +16,8 @@ def test_regular_output_visible_after_loop():
     step = {
         "name": "loop",
         "type": "for-each",
-        "input": "${items}",
-        "item_var": "item",
+        "in": "${items}",
+        "for": "item",
         "steps": [
             {
                 "name": "make_dict",
@@ -44,8 +44,8 @@ def test_last_iteration_wins():
     step = {
         "name": "loop",
         "type": "for-each",
-        "input": "${items}",
-        "item_var": "item",
+        "in": "${items}",
+        "for": "item",
         "steps": [
             {
                 "name": "make_dict",
@@ -71,8 +71,8 @@ def test_append_to_and_regular_output_both_propagate():
     step = {
         "name": "loop",
         "type": "for-each",
-        "input": "${items}",
-        "item_var": "item",
+        "in": "${items}",
+        "for": "item",
         "steps": [
             {
                 "name": "make_dict",
@@ -104,8 +104,8 @@ def test_output_after_loop_usable_in_next_step():
     foreach_step = {
         "name": "loop",
         "type": "for-each",
-        "input": "${items}",
-        "item_var": "item",
+        "in": "${items}",
+        "for": "item",
         "steps": [
             {
                 "name": "capture",

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -151,9 +151,9 @@ class TestForEachGroupBy:
             context = {"items": [{"div": "A"}, {"div": "B"}, {"div": "A"}]}
             step = {
                 "name": "loop", "type": "for-each",
-                "input": "${items}",
+                "in": "${items}",
                 "group-by": "${item.div}",
-                "item_var": "group",
+                "for": "group",
                 "steps": [{
                     "name": "cap", "type": "function",
                     "function": "__gb_test1.capture",
@@ -178,9 +178,9 @@ class TestForEachGroupBy:
             context = {"items": [{"k": "B"}, {"k": "A"}, {"k": "B"}]}
             step = {
                 "name": "loop", "type": "for-each",
-                "input": "${items}",
+                "in": "${items}",
                 "group-by": "${item.k}",
-                "item_var": "group",
+                "for": "group",
                 "steps": [{
                     "name": "rec", "type": "function",
                     "function": "__gb_test2.record",
@@ -202,10 +202,10 @@ class TestForEachGroupBy:
             context = {"items": [{"k": "C"}, {"k": "A"}, {"k": "B"}]}
             step = {
                 "name": "loop", "type": "for-each",
-                "input": "${items}",
+                "in": "${items}",
                 "group-by": "${item.k}",
                 "order-by": "${group.key}",
-                "item_var": "group",
+                "for": "group",
                 "steps": [{
                     "name": "rec", "type": "function",
                     "function": "__gb_test3.record",
@@ -226,11 +226,11 @@ class TestForEachGroupBy:
             context = {"items": [{"k": "A"}, {"k": "C"}, {"k": "B"}]}
             step = {
                 "name": "loop", "type": "for-each",
-                "input": "${items}",
+                "in": "${items}",
                 "group-by": "${item.k}",
                 "order-by":
                     {"key": "${group.key}", "direction": "descending"},
-                "item_var": "group",
+                "for": "group",
                 "steps": [{
                     "name": "rec", "type": "function",
                     "function": "__gb_test4.record",
@@ -254,10 +254,10 @@ class TestForEachGroupBy:
             ]}
             step = {
                 "name": "loop", "type": "for-each",
-                "input": "${items}",
+                "in": "${items}",
                 "group-by": "${item.div}",
                 "order-by": "${group.key}",
-                "item_var": "group",
+                "for": "group",
                 "steps": [{
                     "name": "id", "type": "function",
                     "function": "__gb_test5.identity",
@@ -284,10 +284,10 @@ class TestForEachGroupBy:
             ]}
             step = {
                 "name": "loop", "type": "for-each",
-                "input": "${items}",
+                "in": "${items}",
                 "group-by": "${item.div}",
                 "order-by": "${group.key}",
-                "item_var": "group",
+                "for": "group",
                 "parallel": 3,
                 "steps": [{
                     "name": "id", "type": "function",
@@ -314,10 +314,10 @@ class TestForEachGroupBy:
             context = {"items": [{"div": "X"}, {"div": "Y"}]}
             step = {
                 "name": "loop", "type": "for-each",
-                "input": "${items}",
+                "in": "${items}",
                 "group-by": "${item.div}",
                 "order-by": "${group.key}",
-                "item_var": "group",
+                "for": "group",
                 "steps": [{
                     "name": "rec", "type": "function",
                     "function": "__gb_test7.record",
@@ -337,9 +337,9 @@ class TestForEachGroupBy:
             context = {"items": []}
             step = {
                 "name": "loop", "type": "for-each",
-                "input": "${items}",
+                "in": "${items}",
                 "group-by": "${item.div}",
-                "item_var": "group",
+                "for": "group",
                 "steps": [{
                     "name": "n", "type": "function",
                     "function": "__gb_test8.noop",
@@ -360,9 +360,9 @@ class TestForEachGroupBy:
             context = {"items": [{"n": 3}, {"n": 1}, {"n": 2}]}
             step = {
                 "name": "loop", "type": "for-each",
-                "input": "${items}",
+                "in": "${items}",
                 "order-by": "${item.n}",
-                "item_var": "x",
+                "for": "x",
                 "steps": [{
                     "name": "id", "type": "function",
                     "function": "__gb_test9.identity",
@@ -447,7 +447,7 @@ class TestLintGroupBy:
     def test_lint_pipeline_steps_recognises_group_by(self):
         steps = [{
             "name": "bad", "type": "for-each",
-            "input": "${items}", "item_var": "x",
+            "in": "${items}", "for": "x",
             "group-by": "${book}",   # should error
             "steps": [{}],
         }]
@@ -457,7 +457,7 @@ class TestLintGroupBy:
     def test_lint_pipeline_steps_valid_group_by_no_errors(self):
         steps = [{
             "name": "ok", "type": "for-each",
-            "input": "${items}", "item_var": "group",
+            "in": "${items}", "for": "group",
             "group-by": "${item.division_id}",
             "order-by": "${group.key}",
             "steps": [{"name": "x", "type": "function", "function": "f"}],

--- a/tests/test_issue_117_foreach_function_scope.py
+++ b/tests/test_issue_117_foreach_function_scope.py
@@ -28,8 +28,8 @@ def test_function_step_output_accessible_in_same_iteration():
     step = {
         "name": "process_items",
         "type": "for-each",
-        "input": "${items}",
-        "item_var": "item",
+        "in": "${items}",
+        "for": "item",
         "steps": [
             # Step 1: create enriched dict
             {

--- a/tests/test_linter_append_to.py
+++ b/tests/test_linter_append_to.py
@@ -113,8 +113,8 @@ def test_linter_catches_append_to_in_nested_for_each():
                 {
                     "name": "outer_loop",
                     "type": "for-each",
-                    "input": ["item1", "item2"],
-                    "item_var": "item",
+                    "in": ["item1", "item2"],
+                    "for": "item",
                     "steps": [
                         {
                             "name": "nested_generate",
@@ -479,14 +479,14 @@ def test_linter_catches_append_to_in_deeply_nested_structure():
                 {
                     "name": "outer_loop",
                     "type": "for-each",
-                    "input": ["a", "b"],
-                    "item_var": "item",
+                    "in": ["a", "b"],
+                    "for": "item",
                     "steps": [
                         {
                             "name": "middle_loop",
                             "type": "for-each",
-                            "input": ["1", "2"],
-                            "item_var": "subitem",
+                            "in": ["1", "2"],
+                            "for": "subitem",
                             "steps": [
                                 {
                                     "name": "inner_step",

--- a/tests/test_linter_integration.py
+++ b/tests/test_linter_integration.py
@@ -109,8 +109,8 @@ variables:
 steps:
   - name: loop
     type: for-each
-    input: items
-    item_var: item
+    in: items
+    for: item
     steps:
       - name: nested-step
         type: llm

--- a/tests/test_linter_variable_validation.py
+++ b/tests/test_linter_variable_validation.py
@@ -213,8 +213,8 @@ class TestValidateAllVariableReferences:
             {
                 "name": "process_items",
                 "type": "for-each",
-                "input": "${items}",
-                "item_var": "item",
+                "in": "${items}",
+                "for": "item",
                 "steps": [
                     {
                         "name": "inner",
@@ -238,8 +238,8 @@ class TestValidateAllVariableReferences:
             {
                 "name": "outer",
                 "type": "for-each",
-                "input": "${sections}",
-                "item_var": "section",
+                "in": "${sections}",
+                "for": "section",
                 "steps": [
                     {
                         "name": "generate",
@@ -262,8 +262,8 @@ class TestValidateAllVariableReferences:
             {
                 "name": "outer",
                 "type": "for-each",
-                "input": "${items}",
-                "item_var": "item",
+                "in": "${items}",
+                "for": "item",
                 "steps": [
                     {
                         "name": "inner",
@@ -448,8 +448,8 @@ def test_window_advance_inner_outputs_in_scope():
         {
             "name": "segment",
             "type": "window",
-            "input": "${content}",
-            "item_var": "window_content",
+            "in": "${content}",
+            "for": "window_content",
             "size": 10,
             "steps": [
                 {
@@ -498,8 +498,8 @@ def test_window_advance_is_none_condition_no_error():
         {
             "name": "segment",
             "type": "window",
-            "input": "${content}",
-            "item_var": "window_content",
+            "in": "${content}",
+            "for": "window_content",
             "size": 10,
             "steps": [
                 {

--- a/tests/test_llm_prompt_variable_resolution.py
+++ b/tests/test_llm_prompt_variable_resolution.py
@@ -359,8 +359,8 @@ Please expand this entry with semantic domain information."""
                 {
                     "name": "process-entries",
                     "type": "for-each",
-                    "input": "${status}",
-                    "item_var": "row",
+                    "in": "${status}",
+                    "for": "row",
                     "steps": [
                         {
                             "name": "find-entry",

--- a/tests/test_loop_variable.py
+++ b/tests/test_loop_variable.py
@@ -49,8 +49,8 @@ def _run(items, extra_steps=None, item_var="item"):
     step = {
         "name": "loop",
         "type": "for-each",
-        "input": "${items}",
-        "item_var": item_var,
+        "in": "${items}",
+        "for": item_var,
         "steps": steps,
     }
     run_for_each_step(step, context, {})
@@ -161,14 +161,14 @@ class TestNestedLoopVariable:
         step = {
             "name": "outer_loop",
             "type": "for-each",
-            "input": "${outer}",
-            "item_var": "outer_item",
+            "in": "${outer}",
+            "for": "outer_item",
             "steps": [
                 {
                     "name": "inner_loop",
                     "type": "for-each",
-                    "input": "${inner}",
-                    "item_var": "inner_item",
+                    "in": "${inner}",
+                    "for": "inner_item",
                     "steps": [
                         {
                             "name": "capture",
@@ -212,8 +212,8 @@ class TestLoopNotLeakedToParent:
         step = {
             "name": "loop",
             "type": "for-each",
-            "input": "${items}",
-            "item_var": "item",
+            "in": "${items}",
+            "for": "item",
             "steps": [
                 _capture_step("snap", append_to="snaps"),
             ],

--- a/tests/test_parallel_for_each.py
+++ b/tests/test_parallel_for_each.py
@@ -158,8 +158,8 @@ class TestParallelMatchesSequential:
             step = {
                 "name": "loop",
                 "type": "for-each",
-                "input": "${items}",
-                "item_var": "x",
+                "in": "${items}",
+                "for": "x",
                 "parallel": parallel,
                 "steps": [
                     {
@@ -202,8 +202,8 @@ class TestParallelMatchesSequential:
             step = {
                 "name": "loop",
                 "type": "for-each",
-                "input": "${items}",
-                "item_var": "x",
+                "in": "${items}",
+                "for": "x",
                 "parallel": 3,
                 "steps": [
                     {
@@ -228,8 +228,8 @@ class TestParallelMatchesSequential:
             step = {
                 "name": "loop",
                 "type": "for-each",
-                "input": "${items}",
-                "item_var": "x",
+                "in": "${items}",
+                "for": "x",
                 "parallel": 4,
                 "steps": [
                     {
@@ -257,7 +257,7 @@ class TestParallelMatchesSequential:
                 ctx = {"items": items}
                 s = {
                     "name": "loop", "type": "for-each",
-                    "input": "${items}", "item_var": "x",
+                    "in": "${items}", "for": "x",
                     "steps": [{
                         "name": "do", "type": "function",
                         "function": f"{mod}.identity",
@@ -296,8 +296,8 @@ class TestParallelExceptionPropagation:
             step = {
                 "name": "loop",
                 "type": "for-each",
-                "input": "${items}",
-                "item_var": "x",
+                "in": "${items}",
+                "for": "x",
                 "parallel": 3,
                 "steps": [
                     {
@@ -329,8 +329,8 @@ class TestParallelAfterExit:
             step = {
                 "name": "loop",
                 "type": "for-each",
-                "input": "${items}",
-                "item_var": "x",
+                "in": "${items}",
+                "for": "x",
                 "parallel": 3,
                 "steps": [
                     {
@@ -363,7 +363,7 @@ class TestLintForEachParallel:
 
     def test_no_parallel_no_error(self):
         step = {
-            "name": "loop", "type": "for-each", "input": "${items}",
+            "name": "loop", "type": "for-each", "in": "${items}",
             "steps": [
                 {"outputs": "v", "append_to": "results"},
                 {"inputs": {"x": "${results}"}},
@@ -373,7 +373,7 @@ class TestLintForEachParallel:
 
     def test_parallel_1_no_error(self):
         step = {
-            "name": "loop", "type": "for-each", "input": "${items}",
+            "name": "loop", "type": "for-each", "in": "${items}",
             "parallel": 1,
             "steps": [
                 {"outputs": "v", "append_to": "results"},
@@ -384,7 +384,7 @@ class TestLintForEachParallel:
 
     def test_parallel_cross_iteration_ref_is_error(self):
         step = {
-            "name": "loop", "type": "for-each", "input": "${items}",
+            "name": "loop", "type": "for-each", "in": "${items}",
             "parallel": 5,
             "steps": [
                 {"outputs": "v", "append_to": "results"},
@@ -398,7 +398,7 @@ class TestLintForEachParallel:
 
     def test_parallel_no_cross_ref_no_error(self):
         step = {
-            "name": "loop", "type": "for-each", "input": "${items}",
+            "name": "loop", "type": "for-each", "in": "${items}",
             "parallel": 5,
             "steps": [
                 {"outputs": "v", "append_to": "results"},
@@ -409,7 +409,7 @@ class TestLintForEachParallel:
 
     def test_multiple_cross_refs_multiple_errors(self):
         step = {
-            "name": "loop", "type": "for-each", "input": "${items}",
+            "name": "loop", "type": "for-each", "in": "${items}",
             "parallel": 3,
             "steps": [
                 {"outputs": "a", "append_to": "list_a"},
@@ -422,7 +422,7 @@ class TestLintForEachParallel:
 
     def test_nested_cross_ref_detected(self):
         step = {
-            "name": "loop", "type": "for-each", "input": "${items}",
+            "name": "loop", "type": "for-each", "in": "${items}",
             "parallel": 4,
             "steps": [
                 {"outputs": "v", "append_to": "results"},
@@ -438,8 +438,8 @@ class TestLintForEachParallel:
             {
                 "name": "bad_parallel",
                 "type": "for-each",
-                "input": "${items}",
-                "item_var": "x",
+                "in": "${items}",
+                "for": "x",
                 "parallel": 5,
                 "steps": [
                     {"name": "a", "type": "function", "function": "f",
@@ -457,8 +457,8 @@ class TestLintForEachParallel:
             {
                 "name": "ok_parallel",
                 "type": "for-each",
-                "input": "${items}",
-                "item_var": "x",
+                "in": "${items}",
+                "for": "x",
                 "parallel": 5,
                 "steps": [
                     {"name": "a", "type": "function", "function": "f",

--- a/tests/test_regression_scene_duplication.py
+++ b/tests/test_regression_scene_duplication.py
@@ -71,8 +71,8 @@ def test_for_each_variable_isolation_minimal():
                 {
                     "name": "process_each",
                     "type": "for-each",
-                    "input": "${items}",
-                    "item_var": "item",
+                    "in": "${items}",
+                    "for": "item",
                     "steps": [
                         {
                             "name": "capture",
@@ -145,8 +145,8 @@ def test_simple_for_each_context_contamination():
                 {
                     "name": "process_items",
                     "type": "for-each",
-                    "input": "${items}",
-                    "item_var": "item",
+                    "in": "${items}",
+                    "for": "item",
                     "steps": [
                         {
                             "name": "capture_context",
@@ -232,8 +232,8 @@ def test_list_indexing_behavior():
                 {
                     "name": "process_with_for_each",
                     "type": "for-each",
-                    "input": "${test_list}",
-                    "item_var": "item",
+                    "in": "${test_list}",
+                    "for": "item",
                     "steps": [
                         {
                             "name": "capture_indexing",
@@ -316,8 +316,8 @@ def test_append_list_indexing():
                 {
                     "name": "process_scenes",
                     "type": "for-each",
-                    "input": "${scene_list}",
-                    "item_var": "scene",
+                    "in": "${scene_list}",
+                    "for": "scene",
                     "steps": [
                         {
                             "name": "add_to_joshfrost_list",

--- a/tests/test_resolve_none_value.py
+++ b/tests/test_resolve_none_value.py
@@ -83,8 +83,8 @@ class TestResolveNoneInForEach:
         step = {
             "name": "process_items",
             "type": "for-each",
-            "input": "${items}",
-            "item_var": "item",
+            "in": "${items}",
+            "for": "item",
             "steps": [
                 # Step 1: produces a dict with a None field
                 {

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -46,8 +46,8 @@ class TestRunPipeline:
                 {
                     "name": "process_items",
                     "type": "for-each",
-                    "input": "${input_data}",
-                    "item_var": "item",
+                    "in": "${input_data}",
+                    "for": "item",
                     "steps": [
                         {
                             "name": "transform_item",

--- a/tests/test_runner_full.py
+++ b/tests/test_runner_full.py
@@ -393,14 +393,14 @@ class TestIntegration:
         rule = {
             "name": "nested_loop",
             "type": "for-each",
-            "input": "${rows}",
-            "item_var": "row",
+            "in": "${rows}",
+            "for": "row",
             "steps": [
                 {
                     "name": "inner_loop",
                     "type": "for-each",
-                    "input": "${row.tags}",
-                    "item_var": "tag",
+                    "in": "${row.tags}",
+                    "for": "tag",
                     "steps": [
                         {
                             "name": "collect",

--- a/tests/test_scene_concatenation.py
+++ b/tests/test_scene_concatenation.py
@@ -21,8 +21,8 @@ class TestSceneConcatenation:
         rule = {
             "name": "process_scenes",
             "type": "for-each",
-            "input": "${scenes}",
-            "item_var": "scene",
+            "in": "${scenes}",
+            "for": "scene",
             "steps": [
                 {
                     "name": "format_scene",

--- a/tests/test_step_level_config.py
+++ b/tests/test_step_level_config.py
@@ -102,7 +102,7 @@ def test_reasoning_effort_in_responses_api():
     # Simulate the API params building (llm_runner.py lines 352-367)
     api_params = {
         "model": config.get("model", "gpt-5"),
-        "input": [{"role": "user", "content": "test"}],
+        "in": [{"role": "user", "content": "test"}],
         "tools": [],
         "reasoning": {
             "effort": config.get("reasoning_effort", "medium")

--- a/tests/test_window_advance.py
+++ b/tests/test_window_advance.py
@@ -117,8 +117,8 @@ class TestWindowAdvanceDynamic:
         step = {
             "name": "seg",
             "type": "window",
-            "input": "${content}",
-            "item_var": "wc",
+            "in": "${content}",
+            "for": "wc",
             "size": 10,
             "steps": [
                 {
@@ -141,8 +141,8 @@ class TestWindowAdvanceDynamic:
         step = {
             "name": "seg",
             "type": "window",
-            "input": "${content}",
-            "item_var": "wc",
+            "in": "${content}",
+            "for": "wc",
             "size": 10,
             "steps": [
                 {
@@ -172,8 +172,8 @@ class TestWindowAdvanceDynamic:
         step = {
             "name": "seg",
             "type": "window",
-            "input": "${content}",
-            "item_var": "wc",
+            "in": "${content}",
+            "for": "wc",
             "size": 5,
             "steps": [
                 {
@@ -199,8 +199,8 @@ class TestWindowAdvanceDynamic:
         step = {
             "name": "seg",
             "type": "window",
-            "input": "${content}",
-            "item_var": "wc",
+            "in": "${content}",
+            "for": "wc",
             "size": 5,
             "steps": [
                 _window_advance_step("next_pos"),
@@ -225,8 +225,8 @@ class TestWindowAdvanceDynamic:
         step = {
             "name": "seg",
             "type": "window",
-            "input": "${content}",
-            "item_var": "wc",
+            "in": "${content}",
+            "for": "wc",
             "size": 3,
             "steps": [
                 {
@@ -250,8 +250,8 @@ class TestWindowAdvanceDynamic:
         step = {
             "name": "seg",
             "type": "window",
-            "input": "${content}",
-            "item_var": "wc",
+            "in": "${content}",
+            "for": "wc",
             "size": 10,
             "steps": [
                 {
@@ -287,8 +287,8 @@ class TestWindowAdvanceErrors:
         step = {
             "name": "seg",
             "type": "window",
-            "input": "${content}",
-            "item_var": "wc",
+            "in": "${content}",
+            "for": "wc",
             "size": 5,
             "steps": [_window_advance_step()],
         }
@@ -301,8 +301,8 @@ class TestWindowAdvanceErrors:
         step = {
             "name": "seg",
             "type": "window",
-            "input": "${content}",
-            "item_var": "wc",
+            "in": "${content}",
+            "for": "wc",
             "size": 5,
             "steps": [_window_advance_step()],
         }

--- a/tests/test_window_step.py
+++ b/tests/test_window_step.py
@@ -172,8 +172,8 @@ class TestRunWindowStep:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 2,
             "steps": [
                 {
@@ -193,8 +193,8 @@ class TestRunWindowStep:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 3,
             "include_partial": True,
             "steps": [
@@ -215,8 +215,8 @@ class TestRunWindowStep:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 3,
             "include_partial": False,
             "steps": [
@@ -237,8 +237,8 @@ class TestRunWindowStep:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 3,
             "stride": 1,
             "include_partial": False,
@@ -270,8 +270,8 @@ class TestRunWindowStep:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 2,
             "steps": [],  # empty steps — we'll check context directly
         }
@@ -326,8 +326,8 @@ class TestRunWindowStep:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "pericope",
+            "in": "${items}",
+            "for": "pericope",
             "start_when": "${item.marker == 's'}",
             "end_when": "${item.marker == 'e'}",
             "steps": [
@@ -350,8 +350,8 @@ class TestRunWindowStep:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 3,
             "steps": [
                 {
@@ -371,8 +371,8 @@ class TestRunWindowStep:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 2,
             "steps": [],
         }
@@ -470,8 +470,8 @@ class TestLintWindowStep:
             {
                 "name": "bad_window",
                 "type": "window",
-                "input": "${items}",
-                "item_var": "batch",
+                "in": "${items}",
+                "for": "batch",
                 # Missing size AND start_when — should produce an error
                 "steps": [{"name": "x", "type": "function", "function": "f"}],
             }
@@ -485,8 +485,8 @@ class TestLintWindowStep:
             {
                 "name": "valid_window",
                 "type": "window",
-                "input": "${items}",
-                "item_var": "batch",
+                "in": "${items}",
+                "for": "batch",
                 "size": 3,
                 "steps": [{"name": "x", "type": "function", "function": "f"}],
             }
@@ -513,8 +513,8 @@ class TestWindowFlowControl:
         return {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 2,
             "steps": nested,
         }
@@ -618,14 +618,14 @@ class TestWindowNesting:
         pipeline_step = {
             "name": "outer",
             "type": "for-each",
-            "input": "${groups}",
-            "item_var": "group",
+            "in": "${groups}",
+            "for": "group",
             "steps": [
                 {
                     "name": "inner",
                     "type": "window",
-                    "input": "${group}",
-                    "item_var": "win",
+                    "in": "${group}",
+                    "for": "win",
                     "size": 2,
                     "steps": [
                         {
@@ -659,15 +659,15 @@ class TestWindowNesting:
         pipeline_step = {
             "name": "outer",
             "type": "window",
-            "input": "${items}",
-            "item_var": "win",
+            "in": "${items}",
+            "for": "win",
             "size": 2,
             "steps": [
                 {
                     "name": "inner",
                     "type": "for-each",
-                    "input": "${win}",
-                    "item_var": "ch",
+                    "in": "${win}",
+                    "for": "ch",
                     "steps": [
                         {
                             "name": "record",
@@ -797,8 +797,8 @@ class TestWindowOutputPropagation:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 2,
             "steps": [
                 {
@@ -824,8 +824,8 @@ class TestWindowOutputPropagation:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 2,
             "steps": [
                 {
@@ -855,8 +855,8 @@ class TestWindowOutputPropagation:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 2,
             "steps": [
                 {
@@ -894,8 +894,8 @@ class TestWindowOutputPropagation:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 1,
             "steps": [
                 {
@@ -941,8 +941,8 @@ class TestWindowOutputPropagation:
         step = {
             "name": "w",
             "type": "window",
-            "input": "${items}",
-            "item_var": "batch",
+            "in": "${items}",
+            "for": "batch",
             "size": 1,
             "steps": [
                 {
@@ -1149,8 +1149,8 @@ class TestRunWindowStepToken:
             step = {
                 "name": "tw",
                 "type": "window",
-                "input": "${verses}",
-                "item_var": "chunk",
+                "in": "${verses}",
+                "for": "chunk",
                 "size_by_tokens": 5000,
                 "stride_by_tokens": 0,
                 "model": "gpt-4o",
@@ -1190,8 +1190,8 @@ class TestRunWindowStepToken:
         step = {
             "name": "tw",
             "type": "window",
-            "input": "${items}",
-            "item_var": "my_chunk",
+            "in": "${items}",
+            "for": "my_chunk",
             "size_by_tokens": 5000,
             "stride_by_tokens": 0,
             "model": "gpt-4o",
@@ -1215,42 +1215,33 @@ class TestRunWindowStepToken:
         step = {
             "name": "bad",
             "type": "window",
-            "input": "${v}",
+            "in": "${v}",
+            "for": "w",
             "size_by_tokens": -1,
             "steps": [{}],
         }
         with pytest.raises(ValueError, match="size_by_tokens"):
             run_window_step(step, context, {})
 
-    def test_over_alias_for_input(self):
-        """'over' is accepted as an alias for 'input'."""
-        import sys, types
-        mod = types.ModuleType("__over_alias_mod")
-        mod.get_len = lambda items: len(items)
-        sys.modules["__over_alias_mod"] = mod
-        try:
-            context: dict = {"items": [1, 2, 3]}
-            step = {
-                "name": "w",
-                "type": "window",
-                "over": "${items}",   # alias
-                "size": 2,
-                "include_partial": True,
-                "steps": [
-                    {
-                        "name": "noop",
-                        "type": "function",
-                        "function": "__over_alias_mod.get_len",
-                        "inputs": {"items": "${window}"},
-                        "outputs": "wlen",
-                        "append_to": "lens",
-                    }
-                ],
-            }
-            run_window_step(step, context, {})
-            assert "lens" in context
-        finally:
-            sys.modules.pop("__over_alias_mod", None)
+    def test_legacy_loop_keys_rejected(self):
+        """The removed loop-key aliases fail loud (keys set via vars so the
+        one-off syntax migration can't rewrite them)."""
+        legacy_list_key = "over"      # was an alias for 'in'
+        legacy_loop_key = "item_var"  # was an alias for 'for'
+        context: dict = {"items": [1, 2, 3]}
+
+        # legacy list key, no 'in' -> missing 'in'
+        step_list = {"name": "w", "type": "window", "size": 2, "steps": [{}]}
+        step_list[legacy_list_key] = "${items}"
+        step_list[legacy_loop_key] = "window"
+        with pytest.raises(ValueError, match="missing required 'in'"):
+            run_window_step(step_list, context, {})
+
+        # 'in' present but only the legacy loop key -> missing 'for'
+        step_loop = {"name": "w", "type": "window", "in": "${items}", "size": 2, "steps": [{}]}
+        step_loop[legacy_loop_key] = "window"
+        with pytest.raises(ValueError, match="missing required 'for'"):
+            run_window_step(step_loop, context, {})
 
 
 # ---------------------------------------------------------------------------
@@ -1284,7 +1275,8 @@ class TestWindowMerge:
             step = {
                 "name": "w",
                 "type": "window",
-                "input": "${items}",
+                "in": "${items}",
+                "for": "window",
                 "size": 2,
                 "include_partial": True,
                 "steps": [
@@ -1333,7 +1325,8 @@ class TestWindowMerge:
             step = {
                 "name": "w",
                 "type": "window",
-                "input": "${items}",
+                "in": "${items}",
+                "for": "window",
                 "size": 2,
                 "include_partial": True,
                 "steps": [

--- a/tests/test_xpath_integration.py
+++ b/tests/test_xpath_integration.py
@@ -555,7 +555,8 @@ Process this entry: {entry}""")
                 {
                     "name": "process-each",
                     "type": "for-each",
-                    "input": "${rows}",  # ✅ Changed from "items" to "input"
+                    "for": "item",
+                    "in": "${rows}",
                     "steps": [
                         {
                             "name": "find-entry",


### PR DESCRIPTION
Re-cut of 0.2.1.20 including the for/in loop-syntax migration.

## Breaking
- **One loop syntax: `for`/`in`.** for-each and window steps use XQuery-style `for:`/`in:`;
  the `item_var`/`input`/`over`/`as` aliases are **removed**. Runtime raises and the linter
  flags them (with "did you mean 'for'/'in'?" hints) instead of silently iterating over nothing.

## Also
- Linter fail-loud on unknown step keys; filled real gaps it/the doc-lint surfaced
  (`content`, `key`, `where`, `offset`, `columns`, `response_mime_type`, `response_schema`).
- New `tests/test_doc_examples_lint.py` — lints YAML examples in docs + cli_utils help so docs
  can't silently drift from the schema (caught the `group_by`/`prompt_file` bugs).
- Docs flipped to `for`/`in` (for before in); CLI help `group_by`/`order_by` → hyphenated.
- `RELEASE_CHECKLIST.md` rewritten for build-on-PR/promote-on-tag; design docs added.

## Release mechanics
This PR fires `build.yml` (Linux/macOS/Windows). Per `RELEASE_CHECKLIST.md`: merge as a
**merge commit**, then delete the stale `v0.2.1.20` tag and re-tag the merge commit so
`release.yml` promotes the binaries built here.

Full suite green (2340 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)